### PR TITLE
Fix webview install on ubuntu 14.04

### DIFF
--- a/tasks/build_webview.yml
+++ b/tasks/build_webview.yml
@@ -19,7 +19,7 @@
 - name: install nodejs and npm packages (on Debian)
   when: ansible_os_family == "Debian"
   become: yes
-  shell: "for f in {{ item }}/*; do rm -rf /usr/local/{{ item }}/$(basename $f); mv $f /usr/local/{{ item }}; done"
+  shell: "for f in {{ item }}/*; do rm -rf /usr/local/{{ item }}/$(basename $f); if [ ! -d /usr/local/{{ item }} ]; then mkdir -p /usr/local/{{ item }}; fi; mv $f /usr/local/{{ item }}; done"
   args:
     chdir: /tmp/node-v4.2.4-linux-x64
   with_items:


### PR DESCRIPTION
It was failing on step "install nodejs and npm packages (on Debian)"
because /usr/local/share/systemtap/tapset doesn't exist on ubuntu 14.04