### PR TITLE
Include script to create rhaptos site

### DIFF
--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -110,5 +110,22 @@
 - name: start zeoserver
   shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/zeoserver start
 
+# +++
+# Create Rhaptos Site
+# +++
+
+- name: check whether rhaptos site exists
+  register: rhaptos_site
+  shell: echo 'print(app.site)' | ./bin/instance debug | grep PloneSite
+  args:
+    chdir: "{{ source_dir }}/cnx-buildout"
+  ignore_errors: True
+
+- name: create rhaptos site
+  shell: "./bin/instance run scripts/create_rhaptos_site.py site Portal postgres {{ archive_db_user }} {{ archive_db_name }} {{ archive_db_host }} {{ archive_db_port }}"
+  args:
+    chdir: "{{ source_dir }}/cnx-buildout"
+  when: rhaptos_site|failed
+
 - name: start instance
   shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/instance start


### PR DESCRIPTION
Also have a look at the changes I made to the create_rhaptos_site.py script:

https://github.com/karenc/cnx-buildout/commit/8689ba75a7a96afa02631ccc8fb3a5f220ca5553

`manage_importSelectedSteps` seems to require an empty database (https://github.com/Rhaptos/Products.RhaptosModuleStorage/blob/master/Products/RhaptosModuleStorage/setuphandlers.py#L260), I'm not sure how it's supposed to work.