### PR TITLE
Remove dummy file insertion in acquire_data and push_data

### DIFF
--- a/acquire_data.yml
+++ b/acquire_data.yml
@@ -22,13 +22,16 @@
       shell: nice -n {{ nice_priority }} pg_dump -U {{ db_user }} --exclude-table-data=files --exclude-table-data=module_files {{ db_name }} >cnxarchive_dump_without_files.sql
     - name: dump database files table for index.cnxml, index.cnxml.html, index_auto_generated.cnxml
       shell: nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c "\copy ( SELECT * FROM files WHERE fileid IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO 'cnxarchive_index_files.txt'"
+    - name: dump database files table for other files
+      shell: nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c "\copy ( SELECT fileid, md5, sha1, 'dummy file', media_type FROM files WHERE fileid NOT IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO 'cnxarchive_other_files.txt'"
+
     - name: dump database module files table for index.cnxml, index.cnxml.html, index_auto_generated.cnxml
-      shell: nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c "\copy ( SELECT module_ident, CASE WHEN filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') THEN fileid::text ELSE '<dummy-file-id>' END, filename FROM module_files ) TO 'cnxarchive_index_module_files.txt'"
+      shell: nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c "\copy ( SELECT module_ident, fileid, filename FROM module_files ) TO 'cnxarchive_index_module_files.txt'"
     - name: produce dump filename
       shell: echo "cnxarchive_dump.$(date +'%Y-%m-%d').tar.gz"
       register: dump_filename
     - name: create dump .tar.gz file
-      shell: nice -n {{ nice_priority }} tar czf {{ dump_filename.stdout }} --remove-files cnxarchive_dump_without_files.sql cnxarchive_index_files.txt cnxarchive_index_module_files.txt
+      shell: nice -n {{ nice_priority }} tar czf {{ dump_filename.stdout }} --remove-files cnxarchive_dump_without_files.sql cnxarchive_index_files.txt cnxarchive_other_files.txt cnxarchive_index_module_files.txt
     - name: download dump .tar.gz file
       fetch:
         src: "{{ dump_filename.stdout }}"

--- a/push_data.yml
+++ b/push_data.yml
@@ -29,16 +29,10 @@
       shell: "createdb -O {{ db_user }} {{ db_name }}"
     - name: load database without files
       shell: "psql -U {{ db_user }} {{ db_name }} < /tmp/cnxarchive_dump/cnxarchive_dump_without_files.sql"
+
     - name: load files table
-      shell: psql -U {{ db_user }} {{ db_name }} -c "\copy files FROM '/tmp/cnxarchive_dump/cnxarchive_index_files.txt'"
-    - name: insert dummy file
-      shell: psql -A -U {{ db_user }} {{ db_name }} -c "INSERT INTO files (file) VALUES ('dummy file') RETURNING fileid" | sed -n '2 p'
-      register: dummy_file
-    - name: replace files with dummy file
-      replace:
-        dest: /tmp/cnxarchive_dump/cnxarchive_index_module_files.txt
-        regexp: "<dummy-file-id>"
-        replace: "{{ dummy_file.stdout }}"
+      shell: psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE files DISABLE TRIGGER ALL; COPY files FROM '/tmp/cnxarchive_dump/cnxarchive_index_files.txt'; COPY files (fileid, md5, sha1, file, media_type) FROM '/tmp/cnxarchive_dump/cnxarchive_other_files.txt'; ALTER TABLE files ENABLE TRIGGER ALL;"
+
     - name: load module files table
       shell: psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE module_files DISABLE TRIGGER ALL; COPY module_files FROM '/tmp/cnxarchive_dump/cnxarchive_index_module_files.txt'; ALTER TABLE module_files ENABLE TRIGGER ALL;"
     - name: remove dump files


### PR DESCRIPTION
Instead, just change all the file content (column "file" in files table)
to "dummy file".

This allows us to keep all the entries in the files table, with all the
md5 and sha1 hashes.