### PR TITLE
Run "develop up" to update source code after buildout

### DIFF
--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -109,6 +109,13 @@
     owner: www-data
     group: www-data
 
+- name: update source code
+  become: yes
+  become_user: www-data
+  shell: "bin/develop up -f"
+  args:
+    chdir: "{{ source_dir }}/cnx-buildout"
+
 # +++
 # Start server
 # +++


### PR DESCRIPTION
Running buildout doesn't update the source code in src/, so need to run
the develop script to update the source code.

`-f` is necessary because mr.developer considers extra files in the
directory as dirty and without `-f`, it prompts the user for input:

```
The package 'Products.CMFDiffTool' is dirty.
Do you want to update it anyway? [yes/No/all]
```

Close #39 

:skull: Do not use the merge button.