### PR TITLE
retry and throttle github checkouts

### DIFF
--- a/tasks/checkout.yml
+++ b/tasks/checkout.yml
@@ -7,8 +7,13 @@
     state: directory
 
 - name: clone source
-  git:
+  local_action:
+    module: git
     repo: "{{ item.repo }}"
     dest: "{{ source_dir }}/{{ item.name }}"
     version: "{{ (source_versions is defined and source_versions.get(item.name)) and source_versions[item.name] or item.default_version }}"
   with_items: "{{ source }}"
+  register: git_result
+  until: git_result|success
+  retries: 5
+  delay: 30


### PR DESCRIPTION
This isn't ideal, but works from campus. After the first failure when github throttles (after 4-5 repo clones/checkouts) this fallsback 30 sec. Seems to take approx 2-3 failures and fallbacks to reset the throttle. The checkouts then succeed.