### PR TITLE
Update archive configuration to include new 'sitemap-destination' setting

### DIFF
--- a/templates/etc/cnx/archive/app.ini
+++ b/templates/etc/cnx/archive/app.ini
@@ -37,6 +37,7 @@ exports-allowable-types =
     epub:epub,application/epub+zip,EPUB,Electronic book format file, for viewing on mobile devices.
     zip:zip,application/zip,Offline ZIP,An offline HTML copy of the content.  Also includes XML, included media files, and other support files.
 
+sitemap-destination = http://{{ frontend_domain }}/sitemap.xml
 
 ###
 # wsgi server configuration


### PR DESCRIPTION
This is in response to Connexions/cnx-archive#440,
which added the required setting called, 'sitemap-destination'.

Fixes #51

:skull: **DO NOT MERGE this pull request** :skull:

This project is manually merged. This pull request is only for review and comment.