### PR TITLE
Change copy to not use unprivileged user to work with ansible >2.1

### DIFF
--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -68,10 +68,10 @@
 
 - name: copy cached python packages downloads directory
   become: yes
-  become_user: www-data
   copy:
     src: src/cnx-buildout/downloads
     dest: "{{ source_dir }}/cnx-buildout"
+    owner: www-data
 
 - name: run bootstrap
   become: yes


### PR DESCRIPTION
```
TASK [copy cached python packages downloads directory] *************************
fatal: [cte-legacy-dev.cnx.org]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user. For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}
```

:skull:￼ **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.