### PR TITLE
Plone fixes

### DIFF
--- a/plone.yml
+++ b/plone.yml
@@ -75,6 +75,11 @@
   tasks:
     - include: tasks/plant_source.yml
 
+- name: install supervisor
+  hosts: zope-plone
+  tasks:
+    - include: tasks/install_supervisor.yml
+
 - name: install cnx plone site
   hosts: zope-plone
   tasks:

--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -41,5 +41,4 @@
 
 - name: start instance
   become: yes
-  become_user: www-data
-  shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/instance start
+  shell: supervisorctl restart plone-instance

--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -68,10 +68,10 @@
 
 - name: copy cached python packages downloads directory
   become: yes
-  become_user: www-data
   copy:
     src: src/cnx-buildout/downloads
     dest: "{{ source_dir }}/cnx-buildout"
+    owner: www-data
 
 - name: run bootstrap
   become: yes

--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -120,27 +120,16 @@
 # Start server
 # +++
 
-- stat:
-    path: "{{ source_dir }}/cnx-buildout/var/instance.pid"
-  register: instance_pid
-
-- name: stop instance
+- name: configure zeoserver and instance under supervisor
   become: yes
-  become_user: www-data
-  shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/instance stop
-  when: instance_pid.stat.exists
+  template:
+    src: etc/supervisor/conf.d/plone.conf
+    dest: "{{ root_prefix }}/etc/supervisor/conf.d/plone.conf"
+    mode: 0644
 
-- stat:
-    path: "{{ source_dir }}/cnx-buildout/var/zeoserver.pid"
-  register: zeoserver_pid
-
-- name: stop zeoserver
+- name: restart supervisor
   become: yes
-  become_user: www-data
-  shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/zeoserver stop
-  when: zeoserver_pid.stat.exists
-
-- name: start zeoserver
-  become: yes
-  become_user: www-data
-  shell: chdir="{{ source_dir }}/cnx-buildout" ./bin/zeoserver start
+  service:
+    name: supervisor
+    state: restarted
+    sleep: 5

--- a/tasks/install_python24.yml
+++ b/tasks/install_python24.yml
@@ -14,6 +14,8 @@
     state: present
   with_items:
     - build-essential
+    - libreadline6-dev
+    - libncurses5-dev
     # Required for zlib support in python.
     # See also, http://fnch.users.sourceforge.net/pythononubuntu1104.html
     - dpkg-dev
@@ -90,3 +92,8 @@
   file:
     path: pip-1.1
     state: absent
+
+- name: install readline
+  become: yes
+  pip:
+    name: readline

--- a/tasks/install_python24.yml
+++ b/tasks/install_python24.yml
@@ -56,7 +56,7 @@
 
 - name: download setuptools
   get_url:
-    url: https://bitbucket.org/pypa/setuptools/raw/bootstrap-py24/ez_setup.py
+    url: https://raw.githubusercontent.com/pypa/setuptools/bootstrap-py24/ez_setup.py
     dest: .
 
 - name: install setuptools

--- a/templates/etc/supervisor/conf.d/plone.conf
+++ b/templates/etc/supervisor/conf.d/plone.conf
@@ -1,0 +1,11 @@
+[program:zeoserver]
+command={{ root_prefix }}/var/lib/cnx/cnx-buildout/bin/zeoserver fg
+user=www-data
+directory={{ root_prefix }}/var/lib/cnx/cnx-buildout
+stopwaitsecs=60
+
+[program:plone-instance]
+command={{ root_prefix }}/var/lib/cnx/cnx-buildout/bin/instance console
+user=www-data
+directory={{ root_prefix }}/var/lib/cnx/cnx-buildout
+stopwaitsecs=60


### PR DESCRIPTION
This includes commits from #58.

---

 - Update ez_setup.py url for python 2.4
    
    setuptools moved from bitbucket to github.

 - Install readline for python2.4
    
    Close #50

 - Use supervisor to manage plone zeoserver and instance
                                            
    See http://docs.plone.org/manage/deploying/processes.html

---

:skull:￼￼ **DO NOT MERGE this pull request** ￼￼:skull:

This project is manually merged. This pull request is only for review and comment.