### PR TITLE
Populate the ZODB from the postgres database entries

### DIFF
--- a/environments/cte-dev/host_vars/cte-legacy-dev.cnx.org
+++ b/environments/cte-dev/host_vars/cte-legacy-dev.cnx.org
@@ -1,3 +1,5 @@
 ---
 source_dir: /var/lib/cnx
 local_source_dir: "{{ '~/cnx/src' | expanduser }}"
+
+archive_db_host: cte-cnx-dev.cnx.org

--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -39,6 +39,14 @@
     name: rhaptos
     state: absent
 
+- name: create zope objects from database (background job)
+  when: rhaptos_site|failed
+  become: yes
+  become_user: www-data
+  shell: ./bin/instance run scripts/build_zodb_from_postgres.py
+  args:
+    chdir: "{{ source_dir }}/cnx-buildout"
+
 - name: start instance
   become: yes
   shell: supervisorctl restart plone-instance


### PR DESCRIPTION
When a user views a page on zope, if the object doesn't exist in the
ZODB but is in the postgres database, there is code to create the ZODB
objects.  This commit gets all the urls for collections and modules for
the zope site and use wget to access them so the ZODB objects are
created.

Close #47

Set `archive_db_host` to `cte-cnx-dev.cnx.org` for `cte-legacy-dev.cnx.org`

---

:skull: **DO NOT MERGE this pull request** :skull: ￼￼

This project is manually merged. This pull request is only for review and comment.