### PR TITLE
Set up stub accounts if accounts_domain is not set

### DIFF
--- a/templates/etc/cnx/authoring/app.ini
+++ b/templates/etc/cnx/authoring/app.ini
@@ -28,6 +28,7 @@ current-license-urls =
 # size limit of file upload in MB
 authoring.file_upload.limit = 50
 
+{% if accounts_domain %}
 {% if (accounts_disable_verify_ssl is defined and accounts_disable_verify_ssl)
       or inventory_dir.endswith('environments/local') %}
 openstax_accounts.disable_verify_ssl = true
@@ -35,6 +36,15 @@ openstax_accounts.disable_verify_ssl = true
 openstax_accounts.server_url = https://{{ accounts_domain }}
 openstax_accounts.application_id = {{ accounts_consumer_token }}
 openstax_accounts.application_secret = {{ accounts_consumer_secret }}
+{% else %}
+openstax_accounts.stub = true
+openstax_accounts.stub.message_writer = log
+openstax_accounts.stub.users =
+  admin,password
+  user1,password
+  user2,password
+  impicky,password
+{% endif %}
 
 openstax_accounts.application_url = https://{{ frontend_domain }}/
 openstax_accounts.login_path = /login

--- a/templates/etc/cnx/publishing/app.ini
+++ b/templates/etc/cnx/publishing/app.ini
@@ -30,6 +30,7 @@ api-key-authnz =
   developer,g:publishers
   4e8,loading-zone,
 
+{% if accounts_domain %}
 {% if (accounts_disable_verify_ssl is defined and accounts_disable_verify_ssl)
       or inventory_dir.endswith('environments/local') %}
 openstax_accounts.disable_verify_ssl = true
@@ -42,6 +43,20 @@ openstax_accounts.application_secret = {{ accounts_consumer_secret }}
 openstax_accounts.groups.moderators =
 # TODO administrators?
 openstax_accounts.groups.administrators =
+{% else %}
+openstax_accounts.stub = true
+openstax_accounts.stub.message_writer = log
+openstax_accounts.stub.users =
+  admin,password
+  user1,password
+  user2,password
+  impicky,password
+openstax_accounts.groups.moderators =
+  impicky
+  admin
+openstax_accounts.groups.administrators =
+  admin
+{% endif %}
 openstax_accounts.application_url = https://{{ arclishing_domain }}/
 openstax_accounts.login_path = /login
 openstax_accounts.callback_path = /callback

--- a/templates/etc/nginx/sites-available/webview
+++ b/templates/etc/nginx/sites-available/webview
@@ -13,6 +13,13 @@ server {
     # try_files       $uri @prerender;
     try_files       $uri $uri/ /index.html;
 
+    {% if not accounts_domain %}
+
+    location /stub-login-form {
+        proxy_pass http://{{ authoring_host }}:{{ authoring_port }};
+    }
+    {% endif %}
+
     location /login {
         proxy_pass http://{{ authoring_host }}:{{ authoring_port }};
     }

--- a/templates/etc/varnish/varnish.vcl
+++ b/templates/etc/varnish/varnish.vcl
@@ -114,7 +114,14 @@ sub vcl_recv {
 
     # cnx rewrite archive  - specials served from nginx statically
     if (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.xml") {
+    {% if accounts_domain %}
+
         if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
+    {% else %}
+
+        if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|stub-login-form|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
+    {% endif %}
+
             set req.backend_hint = rewrite_publish;
             return (pass);
         }


### PR DESCRIPTION
Set the openstax_accounts stub flag if accounts_domain is not set.  For
example using the vm environment, if accounts is not set up, it is
possible to use the stub by doing:

```
ansible-playbook -i environments/vm/inventory main.yml -e accounts_domain=
```

---

:skull: **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.