### PR TITLE
Fix the installation of cssselect2 with an additional argument to pip

### DIFF
--- a/tasks/install_publishing.yml
+++ b/tasks/install_publishing.yml
@@ -180,6 +180,7 @@
     name: "git+https://github.com/Connexions/cssselect2.git#egg=cssselect2"
     virtualenv: "{{ root_prefix }}/var/cnx/venvs/publishing"
     state: present
+    extra_args: "--exists-action s"
 # /FIXME cssselect2-acquisition
 
 - name: install (local) publishing packages


### PR DESCRIPTION
The ``exists-action`` setting will ``(s)witch`` to the newly requested
install. Otherwise pip would prompt for user input and as such fail
in ansible.

This problem only occurs because we switched from using the parent
author's version of the project to our connexions' fork.

---

:skull: **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.