### PR TITLE
Add command to update git submodules in src/ in cnx-buildout

### DIFF
--- a/tasks/install_cnx_buildout.yml
+++ b/tasks/install_cnx_buildout.yml
@@ -116,6 +116,17 @@
   args:
     chdir: "{{ source_dir }}/cnx-buildout"
 
+- name: git submodules update
+  become: yes
+  become_user: www-data
+  shell: "for f in {{ source_dir }}/cnx-buildout/src/*; do cd $f && git submodule update --recursive || echo; done"
+
+- name: rerun buildout
+  become: yes
+  shell: ". {{ root_prefix }}/var/cnx/venvs/cnx-buildout/bin/activate && bin/buildout 2>&1 | tee -a buildout_output.txt"
+  args:
+    chdir: "{{ source_dir }}/cnx-buildout"
+
 # +++
 # Start server
 # +++


### PR DESCRIPTION
`bin/buildout` and `bin/develop up` are not updating git submodules, the
only alternative is to remove `src/Products.RhaptosPrint` and then
`bin/develop co Products.RhaptosPrint`, might as well just run the git
command directly.