### PR TITLE
Proxy https scheme

### DIFF
--- a/templates/etc/cnx/archive/app.ini
+++ b/templates/etc/cnx/archive/app.ini
@@ -3,8 +3,16 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
 ###
 
+###
+# Use to pass through X-Forwarded-* headers (i.e. makes https work)
+###
+[filter:proxy-prefix]
+use = egg:PasteDeploy#prefix
+
+
 [app:main]
 use = egg:cnx-archive
+filter-with = proxy-prefix
 
 pyramid.reload_templates = false
 pyramid.debug_authorization = false

--- a/templates/etc/cnx/publishing/app.ini
+++ b/templates/etc/cnx/publishing/app.ini
@@ -3,8 +3,16 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
 ###
 
+###
+# Use to pass through X-Forwarded-* headers (i.e. makes https work)
+###
+[filter:proxy-prefix]
+use = egg:PasteDeploy#prefix
+
+
 [app:main]
 use = egg:cnx-publishing
+filter-with = proxy-prefix
 
 pyramid.reload_templates = false
 pyramid.debug_authorization = false

--- a/templates/etc/nginx/sites-available/ssl
+++ b/templates/etc/nginx/sites-available/ssl
@@ -26,6 +26,11 @@ server {
     location / {
         proxy_pass http://arclishing;
         proxy_set_header host {{ arclishing_domain }};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
         proxy_set_header X-Secure true;
     }
 }
@@ -40,6 +45,11 @@ server {
     location / {
         proxy_pass http://{{ zope_domain }};
         proxy_set_header host {{ zope_domain }};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
         proxy_set_header X-Secure true;
     }
 }
@@ -53,6 +63,11 @@ server {
     location / {
         proxy_pass http://frontend;
         proxy_set_header host {{ frontend_domain }};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Port 443;
         proxy_set_header X-Secure true;
     }
 }


### PR DESCRIPTION
We needed to proxy information through the request pipeline in order to have the underlying machinery understand that this is a proxied request that is using SSL.

The solution here is to set `X-Forwarded-*` headers in the SSL site configuration. Specifically we want the `X-Forwarded-Proto` set, which will tell the underlying applications the protocol/scheme to use when creating URLs. 

The PasteDeploy proxy prefix filter/middleware is used to recognize a request's `X-Forwarded-Proto` header to identify the request scheme and thus set the response scheme. Then the response object can correctly use the scheme to set the `Location` header.

---

:skull: **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.