### PR TITLE
allow forced reload for certain clients

### DIFF
--- a/templates/etc/varnish/varnish.vcl
+++ b/templates/etc/varnish/varnish.vcl
@@ -324,7 +324,7 @@ sub vcl_hit {
             # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#backend-restarts-are-now-retry
             # return (restart);
 
-            return(restart);
+            return(pass);
         } 
     }
 }


### PR DESCRIPTION
The existing 'restart' causes an infinite loop, and a 503. 'pass' sends the req to the backend, bypassing (and refreshing) the cache.