### PR TITLE
Add PasteDeploy's proxy prefix filter to authoring for https support

### DIFF
--- a/templates/etc/cnx/authoring/app.ini
+++ b/templates/etc/cnx/authoring/app.ini
@@ -3,8 +3,16 @@
 # http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
 ###
 
+###
+# Use to pass through X-Forwarded-* headers (i.e. makes https work)
+###
+[filter:proxy-prefix]
+use = egg:PasteDeploy#prefix
+
+
 [app:main]
 use = egg:cnx-authoring
+filter-with = proxy-prefix
 
 session_key = 'seekret'
 # FIXME main host name?


### PR DESCRIPTION
This will allow the redirects in authoring to work correctly rather
than having them send a url with the internal port assigned in the
location header.

This was being observed during deriving a copy for edit. The response's
location header in a 201 after the creation POST contained the hostname
and local port that the python application was running on. This of
course would not resolve because of the combination of SSL and the port
number.

---

:skull: **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.