### PR TITLE
Only start the build zodb script when zope is ready to serve

### DIFF
--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -39,14 +39,16 @@
     name: rhaptos
     state: absent
 
+- name: start instance
+  become: yes
+  shell: supervisorctl restart plone-instance
+
 - name: create zope objects from database (background job)
   when: rhaptos_site|failed
   become: yes
   become_user: www-data
-  shell: ./bin/instance run scripts/build_zodb_from_postgres.py
+  # wait for plone instance to start
+  shell: "while ! nc -w 1 localhost {{ zope_port }}; do sleep 1; done; ./bin/instance run scripts/build_zodb_from_postgres.py -d http://{{ zope_domain }}"
   args:
     chdir: "{{ source_dir }}/cnx-buildout"
-
-- name: start instance
-  become: yes
-  shell: supervisorctl restart plone-instance
+    executable: "/bin/bash"


### PR DESCRIPTION
Depends on https://github.com/Rhaptos/cnx-buildout/pull/13

---

￼:skull: **DO NOT MERGE this pull request** ￼￼:skull:

This project is manually merged. This pull request is only for review and comment.