### PR TITLE
Restucture cnxarchive data dump

### DIFF
--- a/acquire_data.yml
+++ b/acquire_data.yml
@@ -19,21 +19,21 @@
       default: postgres
   tasks:
     - name: dump database without files
-      shell: "nice -n {{ nice_priority }} pg_dump -U {{ db_user }} --exclude-table-data=files --exclude-table-data=module_files {{ db_name }} >cnxarchive_dump_without_files.sql"
+      shell: "nice -n {{ nice_priority }} pg_dump -U {{ db_user }} --exclude-table-data=files --exclude-table-data=module_files {{ db_name }} | gzip > cnxarchive_dump_without_files.sql.gz"
     - name: dump database files table for index.cnxml, index.cnxml.html, index_auto_generated.cnxml
-      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"\\copy ( SELECT * FROM files WHERE fileid IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO 'cnxarchive_index_files.txt'\""
+      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"copy ( SELECT fileid, md5, sha1, file, media_type FROM files WHERE fileid IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO STDOUT\" | gzip > cnxarchive_index_files.txt.gz"
     - name: dump database files table for other files
-      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"\\copy ( SELECT fileid, md5, sha1, 'dummy file', media_type FROM files WHERE fileid NOT IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO 'cnxarchive_other_files.txt'\""
+      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"copy ( SELECT fileid, md5, sha1, 'dummy file', media_type FROM files WHERE fileid NOT IN (SELECT fileid FROM module_files WHERE filename IN ('index.cnxml', 'index.cnxml.html', 'index_auto_generated.cnxml') ) ) TO STDOUT\" | gzip > cnxarchive_other_files.txt.gz"
 
     - name: dump database module files table for index.cnxml, index.cnxml.html, index_auto_generated.cnxml
-      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"\\copy ( SELECT module_ident, fileid, filename FROM module_files ) TO 'cnxarchive_index_module_files.txt'\""
+      shell: "nice -n {{ nice_priority }} psql -U {{ db_user }} {{ db_name }} -c \"copy ( SELECT module_ident, fileid, filename FROM module_files ) TO STDOUT\" | gzip > cnxarchive_index_module_files.txt.gz"
     - name: produce dump filename
-      shell: "echo \"cnxarchive_dump.$(date +'%Y-%m-%d').tar.gz\""
+      shell: "echo \"cnxarchive_dump.$(date +'%Y-%m-%d').tar\""
       register: dump_filename
     - name: create dump .tar.gz file
-      shell: "nice -n {{ nice_priority }} tar czf {{ dump_filename.stdout }} --remove-files cnxarchive_dump_without_files.sql cnxarchive_index_files.txt cnxarchive_other_files.txt cnxarchive_index_module_files.txt"
-    - name: download dump .tar.gz file
+      shell: "nice -n {{ nice_priority }} tar cf {{ dump_filename.stdout }} --remove-files cnxarchive_dump_without_files.sql.gz cnxarchive_index_files.txt.gz cnxarchive_other_files.txt.gz cnxarchive_index_module_files.txt.gz"
+    - name: download dump .tar file
       fetch:
         src: "{{ dump_filename.stdout }}"
-        dest: "cnxarchive_dump.tar.gz"
+        dest: "cnxarchive_dump.tar"
         flat: yes

--- a/push_data.yml
+++ b/push_data.yml
@@ -19,7 +19,7 @@
         path: /tmp/cnxarchive_dump
         state: directory
     - unarchive:
-        src: "cnxarchive_dump.tar.gz"
+        src: "cnxarchive_dump.tar"
         dest: "/tmp/cnxarchive_dump"
     - name: drop database
       become: yes
@@ -31,13 +31,13 @@
       become_user: postgres
       shell: "createdb -O {{ db_user }} {{ db_name }}"
     - name: load database without files
-      shell: "psql -U {{ db_user }} {{ db_name }} < /tmp/cnxarchive_dump/cnxarchive_dump_without_files.sql"
+      shell: "zcat /tmp/cnxarchive_dump/cnxarchive_dump_without_files.sql.gz | psql -U {{ db_user }} {{ db_name }} -f -"
 
     - name: load files table
-      shell: psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE files DISABLE TRIGGER ALL; COPY files FROM '/tmp/cnxarchive_dump/cnxarchive_index_files.txt'; COPY files (fileid, md5, sha1, file, media_type) FROM '/tmp/cnxarchive_dump/cnxarchive_other_files.txt'; ALTER TABLE files ENABLE TRIGGER ALL;"
+      shell: zcat '/tmp/cnxarchive_dump/cnxarchive_index_files.txt.gz' '/tmp/cnxarchive_dump/cnxarchive_other_files.txt.gz' | psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE files DISABLE TRIGGER ALL; COPY files (fileid, md5, sha1, file, media_type) FROM STDIN; ALTER TABLE files ENABLE TRIGGER ALL;"
 
     - name: load module files table
-      shell: psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE module_files DISABLE TRIGGER ALL; COPY module_files FROM '/tmp/cnxarchive_dump/cnxarchive_index_module_files.txt'; ALTER TABLE module_files ENABLE TRIGGER ALL;"
+      shell: zcat '/tmp/cnxarchive_dump/cnxarchive_index_module_files.txt' | psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE module_files DISABLE TRIGGER ALL; COPY module_files (module_ident, fileid, filename) FROM STDIN; ALTER TABLE module_files ENABLE TRIGGER ALL;"
     - name: remove dump files
       file:
         path: /tmp/cnxarchive_dump


### PR DESCRIPTION
compress each dump separately, and decompress on the fly as loading to db, to minimize intermediate size on disk. With current dump, this dropped the extra intermediate overhead from 11GB to 1.7GB.

---

:skull: **DO NOT MERGE this pull request** ￼:skull:

This project is manually merged. This pull request is only for review and comment.