### PR TITLE
Install and configure HAProxy to proxy multiple Zope instances

### DIFF
--- a/environments/cte-dev/group_vars/all/vars.yml
+++ b/environments/cte-dev/group_vars/all/vars.yml
@@ -21,8 +21,6 @@ memcached_hosts: localhost
 
 varnish_port: 80
 
-zope_host: cte-legacy-dev.cnx.org
-zope_port: 8888
 archive_host: archive-cte-cnx-dev.cnx.org
 archive_port: 6789
 publishing_host: archive-cte-cnx-dev.cnx.org

--- a/environments/cte-dev/inventory
+++ b/environments/cte-dev/inventory
@@ -24,6 +24,9 @@ cte-cnx-dev
 [authoring:children]
 cte-cnx-dev
 
+[haproxy:children]
+cte-cnx-dev
+
 [frontend:children]
 cte-cnx-dev
 

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -21,8 +21,6 @@ memcached_hosts: localhost
 
 varnish_port: 80
 
-zope_host: zope.local.cnx.org
-zope_port: 8888
 archive_host: archive.local.cnx.org
 archive_port: 6789
 publishing_host: archive.local.cnx.org

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -24,6 +24,9 @@ local.cnx.org
 [authoring:children]
 local.cnx.org
 
+[haproxy:children]
+local.cnx.org
+
 [frontend:children]
 local.cnx.org
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,8 +24,6 @@ archives_dir: "{{ '~/cnx/archives' | expanduser }}"
 # authoring_db_host: localhost
 # authoring_db_port: 5432
 
-# zope_host: 0.0.0.0
-# zope_port: 8888
 # archive_host: 0.0.0.0
 # archive_port: 6789
 # publishing_host: 0.0.0.0

--- a/group_vars/zclient
+++ b/group_vars/zclient
@@ -1,0 +1,11 @@
+---
+# Variables for zope client configuration
+
+# Ethernet interface on which the load balancer should listen
+# Defaults to the first interface. Change this to:
+#
+#  iface: eth1
+#
+# ...to override.
+#
+iface: '{{ ansible_default_ipv4.interface }}'

--- a/group_vars/zeo
+++ b/group_vars/zeo
@@ -1,0 +1,11 @@
+---
+# Variables for ZEO configuration
+
+# Ethernet interface on which the load balancer should listen
+# Defaults to the first interface. Change this to:
+#
+#  iface: eth1
+#
+# ...to override.
+#
+iface: '{{ ansible_default_ipv4.interface }}'

--- a/haproxy.yml
+++ b/haproxy.yml
@@ -1,0 +1,17 @@
+---
+# Playbook for installing the haproxy service tier
+
+- include: pretask.yml
+
+- name: collect info on zclients hosts
+  hosts:
+    - zclient
+  # NOOP only to acquire IP address information about hosts.
+  tasks: []
+
+- name: haproxy
+  hosts:
+    - haproxy
+  tasks:
+    - include: tasks/install_haproxy.yml
+    - include: tasks/configure_haproxy.yml

--- a/main.yml
+++ b/main.yml
@@ -281,6 +281,8 @@
   tags:
     - zope
 
+- include: haproxy.yml
+
 - name: install frontend
   hosts:
     - frontend

--- a/pretask.yml
+++ b/pretask.yml
@@ -12,6 +12,7 @@
     - zeo
     - zclient
     - pdf_gen
+    - haproxy
   become: yes
   # This is the critical line, otherwise Ansible will try
   # to run python to gather facts.

--- a/tasks/configure_buildout.yml
+++ b/tasks/configure_buildout.yml
@@ -7,7 +7,7 @@
 - name: configure buildout for ansible
   become: yes
   become_user: www-data
-  copy:
+  template:
     src: var/lib/cnx/cnx-buildout/ansible.cfg
     dest: "{{ root_prefix }}/var/lib/cnx/cnx-buildout/ansible.cfg"
     owner: www-data

--- a/tasks/configure_haproxy.yml
+++ b/tasks/configure_haproxy.yml
@@ -1,0 +1,19 @@
+---
+# Configure HAProxy
+
+- name: configure haproxy
+  become: yes
+  template:
+    src: etc/haproxy/haproxy.cfg
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  register: configure_haproxy_task
+
+- name: reload haproxy
+  become: yes
+  when: "{{ configure_haproxy_task|changed }}"
+  service:
+    name: haproxy
+    state: reloaded

--- a/tasks/configure_zclient.yml
+++ b/tasks/configure_zclient.yml
@@ -4,14 +4,22 @@
 # The buildout already contains a section to create an instance.
 # Here want to configure and create several instance configurations.
 
-# TODO Allow for the configuration of the buildout to create more than one instance.
-# TODO Adjust the supervisor template below to include each instance in supervisor.
+# This gets included in the buildout via the configure_buildout.yml task.
+- name: configure frontend(s)
+  become: yes
+  become_user: www-data
+  template:
+    src: var/lib/cnx/cnx-buildout/ansible-zclients.cfg
+    dest: "{{ root_prefix }}/var/lib/cnx/cnx-buildout/ansible-zclients.cfg"
+    owner: www-data
+    group: www-data
+    mode: 0644
 
 - name: configure zclient in supervisor
   become: yes
   template:
-    src: etc/supervisor/conf.d/zclient.conf
-    dest: "{{ root_prefix }}/etc/supervisor/conf.d/zclient.conf"
+    src: etc/supervisor/conf.d/zclients.conf
+    dest: "{{ root_prefix }}/etc/supervisor/conf.d/zclients.conf"
     mode: 0644
 
 # TODO ...

--- a/tasks/install_haproxy.yml
+++ b/tasks/install_haproxy.yml
@@ -1,0 +1,8 @@
+---
+# Install HAProxy
+
+- name: install haproxy
+  become: yes
+  apt:
+    name: haproxy
+    state: present

--- a/templates/etc/haproxy/haproxy.cfg
+++ b/templates/etc/haproxy/haproxy.cfg
@@ -1,0 +1,85 @@
+global
+  log /dev/log    local0
+  log /dev/log    local1 notice
+  chroot /var/lib/haproxy
+  stats socket /run/haproxy/admin.sock mode 660 level admin
+  stats timeout 30s
+  user haproxy
+  group haproxy
+  daemon
+
+  # Default SSL material locations
+  ca-base /etc/ssl/certs
+  crt-base /etc/ssl/private
+
+  # Default ciphers to use on SSL-enabled listening sockets.
+  # For more information, see ciphers(1SSL). This list is from:
+  #  https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+  ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
+  ssl-default-bind-options no-sslv3
+
+defaults
+  log     global
+  mode    http
+  option  httplog
+  option  dontlognull
+  timeout connect 5000
+  timeout client  50000
+  timeout server  50000
+  errorfile 400 /etc/haproxy/errors/400.http
+  errorfile 403 /etc/haproxy/errors/403.http
+  errorfile 408 /etc/haproxy/errors/408.http
+  errorfile 500 /etc/haproxy/errors/500.http
+  errorfile 502 /etc/haproxy/errors/502.http
+  errorfile 503 /etc/haproxy/errors/503.http
+  errorfile 504 /etc/haproxy/errors/504.http
+
+  option httpclose
+  # Remove requests from the queue if people press stop button
+  option abortonclose
+  # Try to connect this many times on failure
+  retries 3
+  # If a client is bound to a particular backend but it goes down,
+  # send them to a different one
+  option redispatch
+  monitor-uri /haproxy-ping
+
+  timeout connect 7s
+  timeout queue   300s
+  timeout client  300s
+  timeout server  300s
+  timeout check   10s
+
+  # Enable status page at this URL, on the port HAProxy is bound to
+  stats enable
+  stats uri /haproxy-status
+  stats refresh 5s
+  stats realm Haproxy statistics
+
+frontend zcluster
+  bind :8888
+  default_backend zclients
+
+# Load balancing over the zope instances
+backend zclients
+  # Use Zope's __ac cookie as a basis for session stickiness if present.
+  # appsession __ac len 32 timeout 1d
+  # Otherwise add a cookie called "serverid" for maintaining session stickiness.
+  # This cookie lasts until the client's browser closes, and is invisible to Zope.
+  #  cookie serverid insert nocache indirect
+  # If no session found, use the roundrobin load-balancing algorithm to pick a backend.
+  balance leastconn
+  # Use / (the default) for periodic backend health checks
+  option httpchk 
+
+  # Server options:
+  # "cookie" sets the value of the serverid cookie to be used for the server
+  # "maxconn" is how many connections can be sent to the server at once
+  # "check" enables health checks
+  # "rise 1" means consider Zope up after 1 successful health check
+{% for host in groups.zclient %}
+{% set ip_addr = hostvars[host]['ansible_' + iface].ipv4.address %}
+{% for i in range(0, hostvars[host].zclient_count|default(1), 1) %}
+  server {{ host }}{{ i }} {{ ip_addr }}:82{{ 80 + i }} check maxconn 4 rise 1
+{% endfor %}
+{% endfor %}

--- a/templates/etc/supervisor/conf.d/zclient.conf
+++ b/templates/etc/supervisor/conf.d/zclient.conf
@@ -1,5 +1,0 @@
-[program:zclient]
-command={{ root_prefix }}/var/lib/cnx/cnx-buildout/bin/instance console
-user=www-data
-directory={{ root_prefix }}/var/lib/cnx/cnx-buildout
-stopwaitsecs=60

--- a/templates/etc/supervisor/conf.d/zclients.conf
+++ b/templates/etc/supervisor/conf.d/zclients.conf
@@ -1,0 +1,8 @@
+{% for i in range(0, hostvars[inventory_hostname].zclient_count|default(1), 1) %}
+[program:zclient_instance{{ i }}]
+command={{ root_prefix }}/var/lib/cnx/cnx-buildout/bin/instance{{ i }} console
+user=www-data
+directory={{ root_prefix }}/var/lib/cnx/cnx-buildout
+stopwaitsecs=60
+
+{% endfor %}

--- a/templates/etc/varnish/varnish.vcl
+++ b/templates/etc/varnish/varnish.vcl
@@ -24,8 +24,8 @@ acl block {
 
 # haproxy load balancing for zope
 backend backend_0 {
-.host = "{{ zope_host }}";
-.port = "{{ zope_port }}";
+.host = "{{ hostvars[groups.haproxy[0]].ansible_default_ipv4.address }}";
+.port = "{{ haproxy_port|default('8888') }}";
 .connect_timeout = 0.4s;
 .first_byte_timeout = 1200s;
 .between_bytes_timeout = 600s;

--- a/templates/var/lib/cnx/cnx-buildout/ansible-zclients.cfg
+++ b/templates/var/lib/cnx/cnx-buildout/ansible-zclients.cfg
@@ -1,0 +1,17 @@
+[buildout]
+extends =
+    base.cfg
+parts +=
+{% for i in range(0, hostvars[inventory_hostname].zclient_count|default(1), 1) %}
+    instance{{ i }}
+{% endfor %}
+backend-ip-address = {{ hostvars[groups.zeo[0]]['ansible_' + iface].ipv4.address|default('127.0.0.1') }}
+
+
+{% for i in range(0, hostvars[inventory_hostname].zclient_count|default(1), 1) %}
+[instance{{ i }}]
+<= instance
+http-address = 82{{ 80 + i }}
+zeo-address = ${buildout:backend-ip-address}:${shared:zeo-port}
+
+{% endfor %}

--- a/templates/var/lib/cnx/cnx-buildout/ansible.cfg
+++ b/templates/var/lib/cnx/cnx-buildout/ansible.cfg
@@ -6,6 +6,10 @@
 extends =
     base.cfg
     libs.cfg
+{% if inventory_hostname in groups.zclient %}
+{# This file is created as part of the zclient configuration #}
+    ansible-zclients.cfg
+{% endif %}
 
 parts +=
     zlibg


### PR DESCRIPTION
This configures, builds and adds init configuration for multiple client instances.
This can be configured using the host variable `zclient_count`.

There is a minor configuration filename change here. `/etc/supervisor/conf.d/zclient.conf` was changed to `/etc/supervisor/conf.d/zclients.conf`(plural). And this configuration does not collide with the previous one so it's not exactly harmful, other than the main `instance` is started, when it shouldn't be. Removing the file corrects the issue. Since we haven't doing any push of this anywhere recently, I don't see a need to put in a task that removes the offending file.
