### PR TITLE
Stop and start services before and after the main push_data tasks

### DIFF
--- a/push_data.yml
+++ b/push_data.yml
@@ -1,7 +1,7 @@
 ---
 # This forcibly wipes and loads data from files/cnxarchive_dump.tar.gz.
 
-- name: forcibly push data
+- name: get database details
   hosts: database
   vars_prompt:
     - name: "db_name"
@@ -13,7 +13,14 @@
     - name: "db_password"
       prompt: "What password should we use for the database user?"
   tasks:
-    - include: tasks/create_db_user.yml
+    - set_fact:
+        db_name: "{{ db_name }}"
+        db_user: "{{ db_user }}"
+        db_password: "{{ db_password }}"
+
+- name: transfer database dump
+  hosts: database
+  tasks:
     - name: create directory for database dump
       file:
         path: /tmp/cnxarchive_dump
@@ -21,6 +28,11 @@
     - unarchive:
         src: "cnxarchive_dump.tar"
         dest: "/tmp/cnxarchive_dump"
+
+- name: forcibly push data
+  hosts: database
+  tasks:
+    - include: tasks/create_db_user.yml
     - name: drop database
       become: yes
       become_user: postgres

--- a/push_data.yml
+++ b/push_data.yml
@@ -29,6 +29,34 @@
         src: "cnxarchive_dump.tar"
         dest: "/tmp/cnxarchive_dump"
 
+- name: stop archive
+  hosts: archive
+  tasks:
+    - shell: supervisorctl stop archive
+      become: yes
+
+- name: stop publishing
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl stop publishing
+      become: yes
+
+- name: stop post publication worker
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl stop post_publication
+      become: yes
+
+- name: stop zclients
+  hosts:
+    - zclient
+    - pdf_gen
+  tasks:
+    - shell: "for i in {0..{{ hostvars[inventory_hostname].zclient_count|default(1) -1 }}}; do supervisorctl stop zclient_instance$i; done"
+      become: yes
+      args:
+        executable: /bin/bash
+
 - name: forcibly push data
   hosts: database
   tasks:
@@ -54,3 +82,39 @@
       file:
         path: /tmp/cnxarchive_dump
         state: absent
+
+- name: start archive
+  hosts: archive
+  tasks:
+    - shell: supervisorctl start archive
+      become: yes
+
+- name: start publishing
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl start publishing
+      become: yes
+
+- name: start post publication worker
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl start post_publication
+      become: yes
+
+- name: start zclients
+  hosts:
+    - zclient
+    - pdf_gen
+  tasks:
+    - shell: "for i in {0..{{ hostvars[inventory_hostname].zclient_count|default(1) - 1 }}}; do supervisorctl start zclient_instance$i; done"
+      become: yes
+      args:
+        executable: /bin/bash
+
+- name: restart varnish
+  hosts: frontend
+  tasks:
+    - service:
+        name: varnish
+        state: restarted
+      become: yes


### PR DESCRIPTION
With services connected to the database, the playbook would error when trying to drop the database.