### PR TITLE
HAproxy for trusty

### DIFF
--- a/tasks/configure_haproxy.yml
+++ b/tasks/configure_haproxy.yml
@@ -3,6 +3,7 @@
 
 - name: configure haproxy
   become: yes
+  when: ansible_distribution_release != "trusty"
   template:
     src: etc/haproxy/haproxy.cfg
     dest: /etc/haproxy/haproxy.cfg
@@ -10,6 +11,25 @@
     group: root
     mode: 0644
   register: configure_haproxy_task
+
+- name: configure haproxy (trusty)
+  become: yes
+  when: ansible_distribution_release == "trusty"
+  template:
+    src: etc/haproxy/haproxy-trusty.cfg
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  register: configure_haproxy_task
+
+- name: enable haproxy (trusty)
+  become: yes
+  when: ansible_distribution_release == "trusty"
+  lineinfile:
+    dest: /etc/default/haproxy
+    regexp: 'ENABLED'
+    line: 'ENABLED=1'
 
 - name: reload haproxy
   become: yes

--- a/tasks/install_postgres.yml
+++ b/tasks/install_postgres.yml
@@ -39,7 +39,6 @@
 
 - name: configure postgres role connection trust
   become: yes
-  become_user: postgres
   template:
     src: etc/postgresql/_/main/pg_hba.conf
     dest: "/etc/postgresql/{{ postgres_version }}/main/pg_hba.conf"

--- a/templates/etc/haproxy/haproxy-trusty.cfg
+++ b/templates/etc/haproxy/haproxy-trusty.cfg
@@ -1,0 +1,75 @@
+global
+  log /dev/log    local0
+  log /dev/log    local1 notice
+  chroot /var/lib/haproxy
+  stats socket /var/run/haproxy.sock mode 660 level admin
+  stats timeout 30s
+  user haproxy
+  group haproxy
+  daemon
+
+defaults
+  log     global
+  mode    http
+  option  httplog
+  option  dontlognull
+  timeout connect 5000
+  timeout client  50000
+  timeout server  50000
+  errorfile 400 /etc/haproxy/errors/400.http
+  errorfile 403 /etc/haproxy/errors/403.http
+  errorfile 408 /etc/haproxy/errors/408.http
+  errorfile 500 /etc/haproxy/errors/500.http
+  errorfile 502 /etc/haproxy/errors/502.http
+  errorfile 503 /etc/haproxy/errors/503.http
+  errorfile 504 /etc/haproxy/errors/504.http
+
+  option httpclose
+  # Remove requests from the queue if people press stop button
+  option abortonclose
+  # Try to connect this many times on failure
+  retries 3
+  # If a client is bound to a particular backend but it goes down,
+  # send them to a different one
+  option redispatch
+  monitor-uri /haproxy-ping
+
+  timeout connect 7s
+  timeout queue   300s
+  timeout client  300s
+  timeout server  300s
+  timeout check   10s
+
+  # Enable status page at this URL, on the port HAProxy is bound to
+  stats enable
+  stats uri /haproxy-status
+  stats refresh 5s
+  stats realm Haproxy statistics
+
+frontend zcluster
+  bind :8888
+  default_backend zclients
+
+# Load balancing over the zope instances
+backend zclients
+  # Use Zope's __ac cookie as a basis for session stickiness if present.
+  # appsession __ac len 32 timeout 1d
+  # Otherwise add a cookie called "serverid" for maintaining session stickiness.
+  # This cookie lasts until the client's browser closes, and is invisible to Zope.
+  #  cookie serverid insert nocache indirect
+  # If no session found, use the roundrobin load-balancing algorithm to pick a backend.
+  balance leastconn
+  # Use / (the default) for periodic backend health checks
+  option httpchk 
+
+  # Server options:
+  # "cookie" sets the value of the serverid cookie to be used for the server
+  # "maxconn" is how many connections can be sent to the server at once
+  # "check" enables health checks
+  # "rise 1" means consider Zope up after 1 successful health check
+{% for host in groups.zclient %}
+{% set ip_addr = hostvars[host]['ansible_' + iface].ipv4.address %}
+{% for i in range(0, hostvars[host].zclient_count|default(1), 1) %}
+  server {{ host }}{{ i }} {{ ip_addr }}:82{{ 80 + i }} check maxconn 4 rise 1
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
This should fix the "Error 503 Backend fetch failed" error on http://legacy-cte-cnx-dev.cnx.org/.

On cte dev which is running trusty (Ubuntu 14.04), haproxy is not running even though it is installed.  There are some differences in configuring haproxy between Ubuntu 14.04 and Ubuntu 16.04.