### PR TITLE
Swap out the database

### DIFF
--- a/dump_into_database.yml
+++ b/dump_into_database.yml
@@ -21,9 +21,19 @@
 
 - name: transfer database
   hosts: database
+  vars:
+    # If working with authoring, set venv_environment to 'authoring' at
+    # and set dbmigrate_context_args value to `--content cnx-authoring`
+    # at runtime.
+    dbmigrate_context_args: "{{ migration_contexts|default('--context cnx-publishing --context cnx-archive') }}"
+    db_connection_string: "dbname={{ db_name }} user=postgres host=localhost port=5432"
   tasks:
     - include: tasks/create_db.yml
       vars:
         db_owner: "postgres"
     - name: pipe database in
       shell: "pg_dump -U postgres -h {{ source_db_host }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
+    - name: initialize db-migrator
+      command: "{{ root_prefix }}/var/cnx/venvs/{{ venv_environment|default('publishing') }}/bin/dbmigrator --db-connection-string \"{{ db_connection_string }}\" {{ dbmigrate_context_args }} init --version 0"
+    - name: migrate database
+      command: "{{ root_prefix }}/var/cnx/venvs/{{ venv_environment|default('publishing') }}/bin/dbmigrator --db-connection-string \"{{ db_connection_string }}\" {{ dbmigrate_context_args }} migrate"

--- a/dump_into_database.yml
+++ b/dump_into_database.yml
@@ -1,0 +1,29 @@
+---
+# This dumps the data from a production server
+# This will dump the data into a new database, initialize db-migrator and migrate the data/schema.
+
+- name: get database details
+  hosts: database
+  vars_prompt:
+    - name: "source_db_host"
+      prompt: "Where is the database hosted?"
+      private: no
+      default: tundra.cnx.rice.edu
+    - name: "db_name"
+      prompt: "What database are we pull from to dump onto this machine?"
+      private: no
+      default: repository
+  tasks:
+    - set_fact:
+        source_db_host: "{{ source_db_host }}"
+        source_db_name: "{{ db_name }}"
+        db_name: "{{ db_name }}_new"
+
+- name: transfer database
+  hosts: database
+  tasks:
+    - include: tasks/create_db.yml
+      vars:
+        db_owner: "postgres"
+    - name: pipe database in
+      shell: "pg_dump -U postgres -h {{ source_db_host }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"

--- a/swap_database.yml
+++ b/swap_database.yml
@@ -1,0 +1,96 @@
+---
+# This will rename a database to swap with an existing one.
+# There will be some downtime during stop services, drop, rename and start services.
+
+- name: get database details
+  hosts: database
+  vars_prompt:
+    - name: "origin_db_name"
+      prompt: "What database are we moving?"
+      private: no
+      default: repository_new
+    - name: "target_db_name"
+      prompt: "What database are we swapping out to (<name>_old)?"
+      private: no
+      default: repository
+  tasks:
+    - set_fact:
+        origin_db_name: "{{ origin_db_name }}"
+        target_db_name: "{{ target_db_name }}"
+        dest_db_name: "{{ target_db_name }}_old"
+
+- name: stop archive
+  hosts: archive
+  tasks:
+    - shell: supervisorctl stop archive
+      become: yes
+
+- name: stop publishing
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl stop publishing
+      become: yes
+
+- name: stop post publication worker
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl stop post_publication
+      become: yes
+
+- name: stop zclients
+  hosts:
+    - zclient
+    - pdf_gen
+  tasks:
+    - shell: "for i in {0..{{ hostvars[inventory_hostname].zclient_count|default(1) -1 }}}; do supervisorctl stop zclient_instance$i; done"
+      become: yes
+      args:
+        executable: /bin/bash
+
+# Varnish is still running and the frontend should be serving stale results.
+
+- name: rename database
+  hosts: database
+  tasks:
+    - name: rename via pgsql
+      shell: |
+        psql -v ON_ERROR_STOP=1 --username postgres <<-" EOSQL"
+        ALTER DATABASE {{ target_db_name }} RENAME TO {{ dest_db_name }};
+        ALTER DATABASE {{ origin_db_name }} RENAME TO {{ target_db_name }};
+        EOSQL
+
+- name: start archive
+  hosts: archive
+  tasks:
+    - shell: supervisorctl start archive
+      become: yes
+
+- name: start publishing
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl start publishing
+      become: yes
+
+- name: start post publication worker
+  hosts: publishing
+  tasks:
+    - shell: supervisorctl start post_publication
+      become: yes
+
+- name: start zclients
+  hosts:
+    - zclient
+    - pdf_gen
+  tasks:
+    - shell: "for i in {0..{{ hostvars[inventory_hostname].zclient_count|default(1) - 1 }}}; do supervisorctl start zclient_instance$i; done"
+      become: yes
+      args:
+        executable: /bin/bash
+
+- name: restart varnish
+  hosts: frontend
+  tasks:
+    - service:
+        name: varnish
+        state: restarted
+      become: yes


### PR DESCRIPTION
If this works as expected, the `dump_into_database.yml` playbook does:
1. dumps the specified database into `${dbname}_new`
2. initializes db-migrator on the database
3. migrates the data/schema using db-migrator

The other playbook, `swap_database.yml`, does:
1. stop all connected services that we know of
2. swap the database into place and leave behind `${dbname}_old`
3. start all services we know of

This is based on the documentation at https://github.com/Connexions/devops/wiki/Copying-Legacy-Production-Data-to-legacy-textbook-qa