### PR TITLE
Add group_vars file for the nfs_connected group

### DIFF
--- a/group_vars/nfs_connected
+++ b/group_vars/nfs_connected
@@ -1,0 +1,11 @@
+---
+# Variables for the NFS connected configuration
+
+# Ethernet interface on which the NFS proc should listen
+# Defaults to the first interface. Change this to:
+#
+#  iface: eth1
+#
+# ...to override.
+#
+iface: '{{ ansible_default_ipv4.interface }}'


### PR DESCRIPTION
This adds an entry-point for the `iface` variable definition of
`nfs_connected` group members. This was mostly taken care of by
other host groups that define iface, but when those host groups are not
defined or are removed from this group, the needed variable becomes
undefined.

Fixes #107