### PR TITLE
Remove all mentions of prerender

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -152,8 +152,6 @@
 # Applications
 # +++
 
-# TODO Prerender
-
 - name: install supervisor
   hosts:
     - archive

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -1,15 +1,8 @@
-{#
-upstream prerender {
-    server          localhost:3000;
-    server          localhost:3001;
-}
-#}
 server {
     listen          8081;
     server_name     {{ frontend_domain }};
     root            /var/www/webview;
     index           index.html;
-    # try_files       $uri @prerender;
     try_files       $uri $uri/ /index.html;
 
     location /login {
@@ -97,30 +90,4 @@ server {
     }
 
     {% endif %}
-{#
-    # Prerender for SEO
-    location @prerender {
-        # Support page prerendering for web crawlers
-        set $prerender 0;
-        if ($http_user_agent ~* "baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest") {
-            set       $prerender 1;
-        }
-        if ($args ~ "_escaped_fragment_") {
-            set       $prerender 1;
-        }
-        if ($http_user_agent ~ "Prerender") {
-            set       $prerender 0;
-        }
-        if ($uri ~ "\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent)$") {
-            set       $prerender 0;
-        }
-        if ($prerender = 1) {
-            rewrite   .* /$scheme://$http_host$request_uri? break;
-            proxy_pass http://prerender;
-        }
-        if ($prerender = 0) {
-            rewrite   .* /index.html break;
-        }
-    }
-#}
 }


### PR DESCRIPTION
The prerender service is no longer used. It was previously used to serve
the results of webview so that search engines could scrape the site.

Fixes #101