### PR TITLE
Configure webview passthrough routes for production

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -214,7 +214,7 @@ sub vcl_recv {
             set req.backend_hint = backend_0;
         }
         // all rewrite webview
-        elsif (req.url ~ "_escaped_fragment_=" || req.url ~ "^/$" || req.url ~ "^/opensearch\.xml" || req.url ~ "^/search" || req.url ~ "^/contents$" || req.url ~ "^/(contents|data|exports|styles|fonts|bower_components|node_modules|images|scripts)/" || req.url ~ "^/(about|about-us|people|contents|donate|tos|browse)" || req.url ~ "^/(login|logout|workspace|callback|users|publish)") {
+        elsif (req.url ~ "_escaped_fragment_=" || req.url ~ "^/$" || req.url ~ "^/opensearch\.xml" || req.url ~ "^/version\.txt" || req.url ~ "^/search" || req.url ~ "^/contents$" || req.url ~ "^/(contents|data|exports|styles|fonts|bower_components|node_modules|images|scripts)/" || req.url ~ "^/(about|about-us|people|contents|donate|tos|browse)" || req.url ~ "^/(login|logout|workspace|callback|users|publish)") {
             set req.backend_hint = rewrite_webview;
 
             if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/users" || req.url ~ "@draft"){

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -214,7 +214,7 @@ sub vcl_recv {
             set req.backend_hint = backend_0;
         }
         // all rewrite webview
-        elsif (req.url ~ "_escaped_fragment_=" || req.url ~ "^/$" || req.url ~ "^/opensearch\.xml" || req.url ~ "^/search" || req.url ~ "^/contents$" || req.url ~ "^/(contents|data|exports|styles|fonts|bower_components|node_modules|images|scripts)/" || req.url ~ "^/(about|about-us|people|contents|donate|tos)"|| req.url ~ "^/(login|logout|workspace|callback|users|publish)") {
+        elsif (req.url ~ "_escaped_fragment_=" || req.url ~ "^/$" || req.url ~ "^/opensearch\.xml" || req.url ~ "^/search" || req.url ~ "^/contents$" || req.url ~ "^/(contents|data|exports|styles|fonts|bower_components|node_modules|images|scripts)/" || req.url ~ "^/(about|about-us|people|contents|donate|tos|browse)" || req.url ~ "^/(login|logout|workspace|callback|users|publish)") {
             set req.backend_hint = rewrite_webview;
 
             if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/users" || req.url ~ "@draft"){


### PR DESCRIPTION
This configures pass through routes in varnish for `/browse` and `/version.txt`. The `/browse` route is only within the production webview, which is why it hasn't been an issue up until now. The `/version.txt` route is new and is being made available as a means of acquiring the webview version in use via `http://.*cnx.org/version.txt`.

Example:
```sh
> http -b http://prod00.cnx.org/version.txt
v0.20.0
```

Fixes #1 