### PR TITLE
Fix configure_hosts playbook to include new host groups

### DIFF
--- a/configure_hosts.yml
+++ b/configure_hosts.yml
@@ -5,9 +5,12 @@
 
 - name: "configure /etc/hosts file"
   hosts:
+    - nfs
     - archive
     - publishing
     - authoring
+    - lead_frontend
+    - legacy_frontend
     - frontend
     - worker
     - database

--- a/group_vars/nfs
+++ b/group_vars/nfs
@@ -1,0 +1,11 @@
+---
+# Variables for the NFS server configuration
+
+# Ethernet interface on which the NFS proc should listen
+# Defaults to the first interface. Change this to:
+#
+#  iface: eth1
+#
+# ...to override.
+#
+iface: '{{ ansible_default_ipv4.interface }}'


### PR DESCRIPTION
This is just a rather simple fix to include the new and existing host groups in the configure_hosts playbook. The nfs host group needed to be added to this playbook in order to mock what we are deploying, which is a dedicated NFS server.