### PR TITLE
Fix the health check for the cnx-suite varnish instances

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -23,7 +23,7 @@
       # Load balancing the frontend grouping
       backend nodes
         balance uri
-        option httpchk OPTIONS * HTTP/1.1\r\nHOST:\ {{ frontend_domain }}
+        option httpchk GET /ping HTTP/1.1\r\nHOST:\ {{ frontend_domain }}
 
         # Server options:
         # "check" enables health checks

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -107,6 +107,11 @@ sub vcl_recv {
         return (synth(403, "Access denied"));
     }
 
+    if (req.url ~ "^/ping") {
+        set req.backend_hint = rewrite_webview;
+        return (pass);
+    }
+
     # cnx rewrite archive
     if (req.url ~ "^/a/") {
             set req.backend_hint = rewrite_publish;

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -5,6 +5,12 @@ server {
     index           index.html;
     try_files       $uri $uri/ /index.html;
 
+    location /ping {
+        add_header Content-Length 0;
+        add_header Content-Type text/plain;
+        return 200;
+    }
+
     location /login {
         proxy_pass http://{{ authoring_host }}:{{ authoring_port }};
     }


### PR DESCRIPTION
This corrects a fault in the health check from HAProxy to its backends.
The OPTIONS method is only available on zope requests. If the zope
front-ends fall down, HAProxy would believe all the backends were down
because the health check failed across all the varnish instances.

This adds a separate `/ping` route to nginx so that the lead load balancer
can tell the difference between a check on the cnx-suite vs legacy.