### PR TITLE
Improved SSL placement

### DIFF
--- a/roles/lead_load_balancer/meta/main.yml
+++ b/roles/lead_load_balancer/meta/main.yml
@@ -1,5 +1,7 @@
 ---
 
 dependencies:
-  - ssl_cert
+  - role: ssl_cert
+    on_ssl_install:
+      - reload haproxy
   - haproxy

--- a/roles/ssl_cert/defaults/main.yml
+++ b/roles/ssl_cert/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+# This is a default NOOP handler for the `on_ssl_install` notifier
+on_ssl_install:
+  - ssl cert NOOP

--- a/roles/ssl_cert/handlers/main.yml
+++ b/roles/ssl_cert/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: ssl cert NOOP
+  # 'false' means we never actually run this task. It is just a place holder.
+  when: false
+  # This is a default NOOP handler for the `on_ssl_install` notifier
+  shell: echo "NOOP"

--- a/roles/ssl_cert/tasks/main.yml
+++ b/roles/ssl_cert/tasks/main.yml
@@ -9,3 +9,4 @@
     owner: "{{ cert_owner|default('root') }}"
     group: "{{ cert_group|default('root') }}"
     mode: 0600
+  notify: "{{ on_ssl_install }}"

--- a/roles/ssl_cert/tasks/main.yml
+++ b/roles/ssl_cert/tasks/main.yml
@@ -1,14 +1,7 @@
 ---
 # Configures SSL sites for cnx sites.
 
-- name: check if certificate is expiring in the next 24 hours
-  become: yes
-  shell: "openssl x509 -checkend $((24 * 60 * 60)) -noout -in {{ root_prefix }}/etc/ssl/certs/{{ frontend_domain }}.pem"
-  ignore_errors: yes
-  register: certificate_expired
-
 - name: install certificate pem
-  when: "{{ certificate_expired.rc != 0 }}"
   become: yes
   copy:
     src: "{{ cert_pem_filepath }}"


### PR DESCRIPTION
We no longer need to do the cert check. Before we did this check because there was a sequence of tasks that were done after it. But recently it was condensed to just putting the .pem in place. So now it really isn’t necessary because the `file` module doesn’t register the task as changed when the file hasn’t changed.