### PR TITLE
Assign varnish memory allocation to specifc hosts

### DIFF
--- a/environments/prod-phase-one/host_vars/prod01.cnx.org
+++ b/environments/prod-phase-one/host_vars/prod01.cnx.org
@@ -1,0 +1,2 @@
+---
+varnish_memory_allocation: 16G

--- a/environments/prod-phase-one/host_vars/prod02.cnx.org
+++ b/environments/prod-phase-one/host_vars/prod02.cnx.org
@@ -1,0 +1,2 @@
+---
+varnish_memory_allocation: 16G

--- a/environments/staging-phase-one/host_vars/staging01.cnx.org
+++ b/environments/staging-phase-one/host_vars/staging01.cnx.org
@@ -1,0 +1,2 @@
+---
+varnish_memory_allocation: 16G

--- a/environments/staging-phase-one/host_vars/staging02.cnx.org
+++ b/environments/staging-phase-one/host_vars/staging02.cnx.org
@@ -1,0 +1,2 @@
+---
+varnish_memory_allocation: 16G


### PR DESCRIPTION
This assigns `16G` to the varnish front-ends in the staging and prod
environments.