### PR TITLE
Supervisorctl

### DIFF
--- a/roles/pdf_gen/tasks/main.yml
+++ b/roles/pdf_gen/tasks/main.yml
@@ -61,5 +61,13 @@
     src: etc/supervisor/conf.d/pdf_gen.conf
     dest: "/etc/supervisor/conf.d/pdf_gen.conf"
     mode: 0644
+  register: supervisor_conf_for_pdf_gen
   notify:
-    - restart supervisord
+    - reload supervisord
+
+- name: restart pdf_gen
+  when: "{{ not supervisor_conf_for_pdf_gen|changed }}"
+  become: yes
+  supervisorctl:
+    name: pdf_gen
+    state: restarted

--- a/roles/supervisorctl/library/supervisorctl.py
+++ b/roles/supervisorctl/library/supervisorctl.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import time
+from functools import partial
+from xmlrpclib import Fault, ServerProxy
+
+__requires__ = 'supervisor'
+import pkg_resources
+
+from ansible.module_utils.basic import AnsibleModule
+from supervisor.xmlrpc import SupervisorTransport
+
+
+DOCUMENTATION = """
+---
+module: supervisorctl
+version: "1.0"
+short_description:  Manage supervisord managed services
+description:
+    - Controls supervisor managed services on remote hosts.
+      (Note, supervisord must be installed)
+options:
+    name:
+        required: true
+        description:
+        - Name of the service.
+    state:
+        required: true
+        choices: [ started, stopped, restarted ]
+        description:
+          - C(started)/C(stopped) are idempotent actions that will not run
+            commands unless necessary.  C(restarted) will always bounce the
+            service.
+    sleep:
+        required: false
+        description:
+        - If the service is being C(restarted) then sleep this many seconds
+          between the stop and start command. This helps to workaround badly
+          behaving init scripts that exit immediately after signaling a process
+          to stop.
+    url:
+        required: false
+        description:
+        - If given, C(url) will be used to connect to via XML-RPC.
+          This C(url) should be in the form of a local socket connection URL.
+          The default for this is unix:///var/run/supervisor.sock.
+"""
+
+EXAMPLES = """
+# Example action to start service httpd, if not running
+- supervisorctl: name=httpd state=started
+# Example action to stop service httpd, if running
+- supervisorctl: name=httpd state=stopped
+# Example action to restart service httpd, in all cases
+- supervisorctl: name=httpd state=restarted
+"""
+
+DEFAULT_URL = 'unix:///var/run/supervisor.sock'
+
+
+def get_state(server, name):
+    info = server.supervisor.getProcessInfo(name)
+    state = info['state']
+    return state
+
+
+def start(server, name, wait=True):
+    state = get_state(server, name) 
+    if 10 <= state <= 20:
+        return None, None
+    return server.supervisor.startProcess(name, wait), None
+
+
+def stop(server, name, wait=True):
+    state = get_state(server, name) 
+    if state == 0:
+        return None, None
+    try:
+        return server.supervisor.stopProcess(name, wait), None
+    except Fault as exc:
+        return False, exc.faultString
+
+
+def restart(server, name, sleep=None):
+    stopped, message = stop(server, name)
+    started, message = start(server, name)
+    if not started:
+        return started, message
+
+    if sleep:
+        time.sleep(sleep)
+    return True, None
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+            state = dict(choices=['started', 'stopped', 'restarted']),
+            sleep = dict(required=False, type='int', default=None),
+            url = dict(required=False, default=DEFAULT_URL),
+        ),
+        supports_check_mode=True,
+    )
+
+    # Only supporting local connections at this time.
+    server_url = module.params['url']
+    transport = SupervisorTransport(None, None, serverurl=server_url)
+    server = ServerProxy('http://127.0.0.1', transport=transport)
+
+    state_funcs = {
+        'started': partial(start, server),
+        'stopped': partial(stop, server),
+        'restarted': partial(restart, server,
+                             sleep=module.params['sleep']),
+    }
+
+    func = state_funcs[module.params['state']]
+
+    try:
+        success, message = func(module.params['name'])
+    except Fault as exc:
+        message = exc.faultString
+        return module.fail_json(msg=message)
+    else:
+        return module.exit_json(changed=success is not None,
+                                msg=message)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/supervisord/handlers/main.yml
+++ b/roles/supervisord/handlers/main.yml
@@ -5,3 +5,11 @@
   service:
     name: supervisor
     state: restarted
+  register: restart_supervisor_handler
+
+- name: reload supervisord
+  when: "{{ restart_supervisor_handler is not defined }}"
+  become: yes
+  service:
+    name: supervisor
+    state: reloaded

--- a/roles/zclient/meta/main.yml
+++ b/roles/zclient/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - supervisord
+  - supervisorctl

--- a/roles/zclient/tasks/main.yml
+++ b/roles/zclient/tasks/main.yml
@@ -6,5 +6,14 @@
     src: etc/supervisor/conf.d/zclients.conf
     dest: "/etc/supervisor/conf.d/zclients.conf"
     mode: 0644
+  register: supervisor_conf_for_zclients
   notify:
-    - restart supervisord
+    - reload supervisord
+
+- name: restart zclients
+  when: "{{ not supervisor_conf_for_zclients|changed }}"
+  become: yes
+  supervisorctl:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "[{% for i in range(0, hostvars[inventory_hostname].zclient_count|default(1), 1) %}'{{ 'zclient_instance{}'.format(i) }}',{% endfor %}]"

--- a/roles/zeo/tasks/main.yml
+++ b/roles/zeo/tasks/main.yml
@@ -11,5 +11,13 @@
     src: etc/supervisor/conf.d/zeo.conf
     dest: "/etc/supervisor/conf.d/zeo.conf"
     mode: 0644
+  register: supervisor_conf_for_zeo
   notify:
-    - restart supervisord
+    - reload supervisord
+
+- name: restart zeo
+  when: "{{ not supervisor_conf_for_zeo|changed }}"
+  become: yes
+  supervisorctl:
+    name: zeo
+    state: restarted

--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -41,7 +41,3 @@
     login_host: "{{ archive_db_host }}"
     port: "{{ archive_db_port }}"
     state: absent
-
-- name: start instance
-  become: yes
-  shell: supervisorctl restart plone-instance

--- a/zope.yml
+++ b/zope.yml
@@ -7,6 +7,13 @@
   hosts: zope
   roles:
     - zope
+  tags:
+    - zope
+
+- name: create site
+  hosts: zope
+  roles:
+    - supervisorctl
   tasks:
     - include: tasks/create_rhaptos_site.yml
       run_once: yes


### PR DESCRIPTION
- This adds a new `supervisorctl` role which contains a new ansible module for controlling the restarts of supervisord managed processes.

- This hopefully fixes out zope component restarts issue. Unfortunately, the fix is to restart the zope services on every run, because the buildout (application build process) doesn't give us any feedback about whether the application was updated or not.

- This moves the rhaptos site creation script into it's own host block to ensure the role's handlers are executed before the task is executed. This is important because ZEO needs to be running before the site can be created.