### PR TITLE
Add role to create a zeopack crontab entry

### DIFF
--- a/roles/zeo/meta/main.yml
+++ b/roles/zeo/meta/main.yml
@@ -2,3 +2,7 @@
 
 dependencies:
   - supervisord
+  - role: zeopack
+    # Default environments should have this, production should disable it
+    # because the backup server does the packing during backup.
+    when: "{{ enable_zeopack|default(True) }}"

--- a/roles/zeopack/tasks/main.yml
+++ b/roles/zeopack/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: create zeopack cronjob
+  become: yes
+  become_user: "www-data"
+  cron:
+    name: zeopack
+    state: present
+    special_time: weekly
+    job: "/var/lib/cnx/cnx-buildout/bin/zeopack"


### PR DESCRIPTION
This role can be disabled by setting `enable_zeopack` to false.
The only place we would want to disable it is in production, because the
backup server does packing during backup.

```sh
www-data@rubble:/var/lib/cnx/cnx-buildout$ crontab -l
#Ansible: zeopack
@weekly /var/lib/cnx/cnx-buildout/bin/zeopack
```

Closes #86 