### PR TITLE
Main playbook refactored

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for managing the database.
 
-- include: pretask.yml
-
 - name: collect info on database connected hosts
   hosts: db_connected
   # NOOP only to acquire IP address information about connected hosts.

--- a/frontend.yml
+++ b/frontend.yml
@@ -1,0 +1,14 @@
+---
+# Install frontend components
+
+- name: install frontend
+  hosts:
+    - frontend
+  roles:
+    - varnish
+    - webview
+  tags:
+    - nginx
+    - varnish
+    - webview
+    - fe

--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for installing the HAProxy service for initial request consumption.
 
-- include: pretask.yml
-
 - name: collect info on connected hosts
   hosts:
     - frontend

--- a/legacy_frontend.yml
+++ b/legacy_frontend.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for installing the haproxy service tier
 
-- include: pretask.yml
-
 - name: collect info on zclients hosts
   hosts:
     - zclient

--- a/main.yml
+++ b/main.yml
@@ -120,12 +120,7 @@
     - legacy_fe
     - fe
 
-- name: install frontend
-  hosts:
-    - frontend
-  roles:
-    - varnish
-    - webview
+- include: frontend.yml
   tags:
     - nginx
     - varnish

--- a/nfs.yml
+++ b/nfs.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for managing an NFS server
 
-- include: pretask.yml
-
 - name: collect info on nfs connected hosts
   hosts: nfs_connected
   # NOOP only to acquire IP address information about connected hosts.

--- a/nfs_connected.yml
+++ b/nfs_connected.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for managing NFS connections
 
-- include: pretask.yml
-
 - name: connect to nfs
   hosts: nfs_connected
   tasks:

--- a/zope.yml
+++ b/zope.yml
@@ -1,8 +1,6 @@
 ---
 # Playbook for managing Zope based services
 
-- include: pretask.yml
-
 - name: install zope based services
   hosts: zope
   roles:


### PR DESCRIPTION
This splits out the frontend components into a separate playbook so it can be run independent of the main playbook. This also removes the pretask call in sub-playbooks. If you call pretask, ensures python2 is installed on the server, which is really only needed during provisioning.