### PR TITLE
Provide a subrole for the pgdg repository entry

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -18,11 +18,15 @@
     - legacy_be
     - be
 
-- name: create databases and users
+- name: install postgres database
   hosts:
     - database
   roles:
     - cnx_database
+
+- name: create databases and users
+  hosts:
+    - database
   tasks:
     - include: tasks/create_db_user.yml
       vars:

--- a/roles/_pgdg_repo/tasks/main.yml
+++ b/roles/_pgdg_repo/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Adds the Postgres repository to the system
+
+- name: add apt-key for pgdg repository
+  become: yes
+  apt_key:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    state: present
+
+- name: add pgdg repository
+  become: yes
+  apt_repository:
+    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+    state: present
+    update_cache: yes

--- a/roles/postgres/meta/main.yml
+++ b/roles/postgres/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - _pgdg_repo

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,19 +1,6 @@
 ---
 # Installs and configures Postgres.
 
-- name: add apt-key for pgdg repository
-  become: yes
-  apt_key:
-    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
-    state: present
-
-- name: add pgdg repository
-  become: yes
-  apt_repository:
-    repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
-    state: present
-    update_cache: yes
-
 - name: install postgres
   become: yes
   apt:


### PR DESCRIPTION
This has been split to allow the role modifications to run their handlers.
This is important because during provisioning we modify connection permissions
that require a configuration reload/restart. The reload/restart wouldn't
happen until the handlers are triggered, which doesn't happen until after
the play has finished its tasks.

We'll reuse this `_pgdg_repo` role during application install for installation of the
latest postgres client libraries.