### PR TITLE
Start the varnishncsa service for logging

### DIFF
--- a/roles/varnish/handlers/main.yml
+++ b/roles/varnish/handlers/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: start varnishncsa
+  become: yes
+  service:
+    name: varnishncsa
+    state: started
+
 - name: restart daemon tools
   become: yes
   # This makes our service file changes available for use.

--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -37,6 +37,8 @@
     state: present
     update_cache: yes
     cache_valid_time: 3600
+  notify:
+    - start varnishncsa
 
 # +++
 # Configure


### PR DESCRIPTION
These changes will ensure the varnishncsa service is started when varnish is installed.

This won't retrofit the exist deploys to start the varnishncsa service. That will be a manual operation we can take care of without too much fuss (i.e. `sudo service varnishncsa start` on prod{01,02,03}, staging{01,02,03} and dev00).



