### PR TITLE
Move archive db init functionality to a separate role

### DIFF
--- a/environments/dev/files/archive-requirements.txt
+++ b/environments/dev/files/archive-requirements.txt
@@ -6,7 +6,7 @@ cnx-epub==0.10.0
 cnx-archive==2.5.1
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/dev/files/publishing-requirements.txt
+++ b/environments/dev/files/publishing-requirements.txt
@@ -9,7 +9,7 @@ openstax-accounts==1.0.0
 cnx-publishing==0.6.0
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/tea/files/archive-requirements.txt
+++ b/environments/tea/files/archive-requirements.txt
@@ -6,7 +6,7 @@ cnx-epub==0.10.0
 cnx-archive==2.5.1
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/tea/files/publishing-requirements.txt
+++ b/environments/tea/files/publishing-requirements.txt
@@ -9,7 +9,7 @@ openstax-accounts==1.0.0
 cnx-publishing==0.6.0
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/vm/files/archive-requirements.txt
+++ b/environments/vm/files/archive-requirements.txt
@@ -6,7 +6,7 @@ cnx-epub==0.10.0
 cnx-archive==2.5.1
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/vm/files/publishing-requirements.txt
+++ b/environments/vm/files/publishing-requirements.txt
@@ -9,7 +9,7 @@ openstax-accounts==1.0.0
 cnx-publishing==0.6.0
 
 db-migrator==0.1.4
-cnx-db==0.2.2
+cnx-db>=0.2
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/roles/archive/meta/main.yml
+++ b/roles/archive/meta/main.yml
@@ -3,6 +3,7 @@
 dependencies:
   - _pgdg_repo
   - python2
+  - archive_db
   - memcached
   - supervisord
   - supervisorctl

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -94,6 +94,8 @@
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"
+  notify:
+    - migrate archive db
 
 # +++
 # Configure
@@ -108,6 +110,8 @@
   with_items:
     - cnx
     - cnx/archive
+  notify:
+    - initialize archive db
 
 - name: render configuration
   become: yes
@@ -124,41 +128,6 @@
     - restart archive
 
 # TODO make logging configuration files for pyramid_sawing
-
-# +++
-# Init databases
-# +++
-
-# Note, the setup current **assumes** that the publishing and archive database
-# is the same database. There has been no reason to split these yet, so we won't.
-
-# FIXME These initialize tasks run to failures. Ideally, it's be nice if
-#       they gracefully bailed out with a meaningful message.
-
-- name: initialize archive db
-  command: "/var/cnx/venvs/archive/bin/cnx-archive-initdb /etc/cnx/archive/app.ini"
-  register: archive_initdb_cmd
-  failed_when: "archive_initdb_cmd.rc > 0 and 'Database is already initialized' not in archive_initdb_cmd.stderr"
-
-- name: initialize venv in db
-  # FIXME (15-Nov-2016) The venv logic only works with localhost at this time.
-  #       It doesn't fail when not localhost, instead it just warns...
-  #       As a result, we are temporarily hardcoding this to localhost, which
-  #       means archive will be required to be on the same host as postgres.
-  #       https://github.com/Connexions/cnx-deploy/issues/145
-  command: "/var/cnx/venvs/archive/bin/cnx-db venv -h localhost -p {{ archive_db_port }} -d {{ archive_db_name }} -U {{ archive_db_user }}"
-
-- name: initialize db-migrator
-  # XXX (16-Mar-2016) standalone installs aren't ideal, because they don't give
-  #     the full picture of what archive is, but we'll roll with it for now.
-  when: "(standalone_archive_install is defined and standalone_archive_install) and 'Database is already initialized' not in archive_initdb_cmd.stderr"
-  command: "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-archive init"
-
-- name: migrate database
-  # XXX (16-Mar-2016) standalone installs aren't ideal, because they don't give
-  #     the full picture of what archive is, but we'll roll with it for now.
-  when: "standalone_archive_install is defined and standalone_archive_install"
-  command: "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-archive migrate"
 
 # +++
 # Init service

--- a/roles/archive_db/files/usr/local/bin/initialize-archive-db
+++ b/roles/archive_db/files/usr/local/bin/initialize-archive-db
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+from __future__ import print_function
+
+import sys
+import argparse
+import shlex
+from subprocess import PIPE, Popen
+
+
+# FIXME These initialize tasks run to failures. Ideally, it's be nice if
+#       they gracefully bailed out with a meaningful message.
+INIT_DB_CMD = "/var/cnx/venvs/archive/bin/cnx-archive-initdb /etc/cnx/archive/app.ini"
+
+# This message is returned by the initdb command when the database exists.
+KNOWN_OK = "Database is already initialized"
+
+
+def call(cmd):
+    """Call a commnd and return the returncode, stdout and stderr."""
+    proc = Popen(shlex.split(cmd), stderr=PIPE, stdout=PIPE)
+    out, err = proc.communicate()
+    return (proc.returncode, out, err,)
+
+
+def print_issue(step, out, err):
+        msg = "Ouch! @ {} \nSTDOUT:\n{}STDERR:\n{}".format(step, out, err)
+        print(msg, file=sys.stderr)
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    # database arguments
+    parser.add_argument('host')
+    parser.add_argument('port')
+    parser.add_argument('name')
+    parser.add_argument('user')
+    parser.add_argument('stand_alone_install', type=int)  # 1 or 0
+    return parser
+
+
+def main(argv=None):
+    parser = make_parser()
+    args = parser.parse_args(argv)
+
+    # Initialize DB
+    retcode, out, err = call(INIT_DB_CMD)
+    if retcode > 0 and KNOWN_OK not in err:
+        print_issue('initdb', out, err)
+        return 1
+
+    # Initialize venv in db
+    # FIXME (15-Nov-2016) The venv logic only works with localhost at this time.
+    #       It doesn't fail when not localhost, instead it just warns...
+    #       As a result, we are temporarily hardcoding this to localhost, which
+    #       means archive will be required to be on the same host as postgres.
+    #       https://github.com/Connexions/cnx-deploy/issues/145
+    cmd = "/var/cnx/venvs/archive/bin/cnx-db venv -h {0.host} -p {0.port} -d {0.name} -U {0.user}".format(args)
+    retcode, out, err = call(cmd)
+    if retcode > 0:
+        print_issue('venv', out, err)
+        return 1
+
+    if args.stand_alone_install:
+        # XXX (16-Mar-2016) standalone installs aren't ideal, because they
+        #     don't give the full picture of what archive is, but we'll
+        #     roll with it for now.
+        #     These procedures would normally run as part of the publishing
+        #     installation because it can provide the full picture.
+
+        # Initialize db-migrator
+        cmd = "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-archive init"
+        retcode, out, err = call(cmd)
+        if retcode > 0:
+            print_issue('dbmigrator init', out, err)
+            return 1
+
+        # Migrate database
+        cmd = "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-archive migrate"
+        retcode, out, err = call(cmd)
+        if retcode > 0:
+            print_issue('dbmigrator migrate', out, err)
+            return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/roles/archive_db/handlers/main.yml
+++ b/roles/archive_db/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+
+# Note, the setup current **assumes** that the publishing and archive database
+# is the same database. There has been no reason to split these yet, so we won't.
+
+- name: initialize archive db
+  command: "/usr/local/bin/initialize-archive-db {{ archive_db_host }} {{ archive_db_port }} {{ archive_db_name }} {{ archive_db_user }} {{ (standalone_archive_install is defined and standalone_archive_install) and 1 or 0 }}"
+  register: initialize_archive_db_cmd
+
+- name: migrate archive db
+  # XXX (16-Mar-2016) standalone installs aren't ideal, because they don't give
+  #     the full picture of what archive is, but we'll roll with it for now.
+  when: "(standalone_archive_install is defined and standalone_archive_install) and initialized_archive_db_cmd is not defined"
+  command: "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-archive migrate"

--- a/roles/archive_db/meta/main.yml
+++ b/roles/archive_db/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - python2

--- a/roles/archive_db/tasks/main.yml
+++ b/roles/archive_db/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# Set up script so aid in the provisioning of the archive database.
+
+- name: create script to initialize archive db
+  become: yes
+  copy:
+    src: usr/local/bin/initialize-archive-db
+    dest: /usr/local/bin/initialize-archive-db
+    mode: 0755


### PR DESCRIPTION
This provides us with a way to do database initialization and migration
only when a known change has occured. In this case, during provisioning we
will notify the initialize db handler. Likewise, during installation or
an update to the installation the db migration will run, but only if there
has been a change to the installation.

This is very different from the previous tasks that ran on every playbook run.

Fixes #145 and removes the temporary fix put in place by #146.