### PR TITLE
Load balanced cnx-suite apps

### DIFF
--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -59,7 +59,8 @@ server {
     # and if they do not exist, fall back to cnx-authoring
     # from http://linuxplayer.org/2013/06/nginx-try-files-on-multiple-named-location-or-server
     location ~ ^/resources/.+ {
-        proxy_pass http://{{ archive_host }}:{{ archive_base_port|default(default_archive_base_port) }};
+        proxy_set_header Host {{ arclishing_domain }};
+        proxy_pass http://localhost:{{ varnish_port }};
         proxy_intercept_errors on;
         recursive_error_pages on;
         error_page 404 = @authoring;
@@ -70,7 +71,8 @@ server {
     }
 
     location /resources/ {
-        proxy_pass  http://{{ archive_host }}:{{ archive_base_port|default(default_archive_base_port) }};
+        proxy_set_header Host {{ arclishing_domain }};
+        proxy_pass http://localhost:{{ varnish_port }};
     }
 
     location ~ ^.*/(data|scripts|styles|images|fonts)/(.*) {


### PR DESCRIPTION
Depends on #185 

💀  **Theses changes are not backwards compatible**. 💀  (The last commit breaks production.) These changes require the cnx-suite to be deployed and managed by cnx-deploy. Acceptance of this pull request means that we will be required to fork a stability version of cnx-deploy (done: see `production` branch) until [Phase Three](https://github.com/Connexions/cnx-deploy/milestone/3) hits production.

This is missing a load balancing element for authoring (see also #186) . But authoring is not used in production and will continue to function regardless of these changes. As such, I've chosen to push this work into the future.