### PR TITLE
Fix permmisions to copy the requirements.txt files

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -81,12 +81,12 @@
 
 - name: copy over requirements.txt
   become: yes
-  become_user: www-data
   copy:
     src: "{{ inventory_dir }}/files/archive-requirements.txt"
     dest: "/var/lib/cnx/archive-requirements.txt"
     owner: www-data
     group: www-data
+    mode: 0755
 
 - name: install archive
   become: yes

--- a/roles/authoring/tasks/main.yml
+++ b/roles/authoring/tasks/main.yml
@@ -82,12 +82,12 @@
 
 - name: copy over requirements.txt
   become: yes
-  become_user: www-data
   copy:
     src: "{{ inventory_dir }}/files/authoring-requirements.txt"
     dest: "/var/lib/cnx/authoring-requirements.txt"
     owner: www-data
     group: www-data
+    mode: 0755
 
 - name: install authoring
   become: yes

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -81,12 +81,12 @@
 
 - name: copy over requirements.txt
   become: yes
-  become_user: www-data
   copy:
     src: "{{ inventory_dir }}/files/publishing-requirements.txt"
     dest: "/var/lib/cnx/publishing-requirements.txt"
     owner: www-data
     group: www-data
+    mode: 0755
 
 - name: install publishing
   become: yes


### PR DESCRIPTION
Apparently `www-data` has the ability to copy things on my local VM, but doesn't have the permissions on our VMs in the CNX space. This changes it so that the root user is placing the file and setting the permissions.