### PR TITLE
Supervisorctl 2.1

### DIFF
--- a/roles/archive/handlers/main.yml
+++ b/roles/archive/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart archive
   become: yes
   supervisorctl:
-    name: "archive:*"
+    group: "archive"
     state: restarted

--- a/roles/archive/handlers/main.yml
+++ b/roles/archive/handlers/main.yml
@@ -2,6 +2,6 @@
 
 - name: restart archive
   become: yes
-  supervisorctl:
+  supervisorctl2:
     group: "archive"
     state: restarted

--- a/roles/authoring/handlers/main.yml
+++ b/roles/authoring/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart authoring
   become: yes
   supervisorctl:
-    name: "authoring:*"
+    group: "authoring"
     state: restarted

--- a/roles/authoring/handlers/main.yml
+++ b/roles/authoring/handlers/main.yml
@@ -2,6 +2,6 @@
 
 - name: restart authoring
   become: yes
-  supervisorctl:
+  supervisorctl2:
     group: "authoring"
     state: restarted

--- a/roles/pdf_gen/tasks/main.yml
+++ b/roles/pdf_gen/tasks/main.yml
@@ -87,6 +87,6 @@
 - name: restart pdf_gen
   when: "{{ not supervisor_conf_for_pdf_gen|changed }}"
   become: yes
-  supervisorctl:
+  supervisorctl2:
     name: pdf_gen
     state: restarted

--- a/roles/publishing/handlers/main.yml
+++ b/roles/publishing/handlers/main.yml
@@ -2,6 +2,6 @@
 
 - name: restart publishing
   become: yes
-  supervisorctl:
+  supervisorctl2:
     group: "publishing"
     state: restarted

--- a/roles/publishing/handlers/main.yml
+++ b/roles/publishing/handlers/main.yml
@@ -3,5 +3,5 @@
 - name: restart publishing
   become: yes
   supervisorctl:
-    name: "publishing:*"
+    group: "publishing"
     state: restarted

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -122,6 +122,8 @@
        dest: "/etc/cnx/publishing/app.ini"}
     - {src: "etc/cnx/publishing/logging.yaml",
        dest: "/etc/cnx/publishing/logging.yaml"}
+  notify:
+    - restart publishing
 
 # TODO make logging configuration files for pyramid_sawing
 

--- a/roles/supervisorctl/library/supervisorctl2.py
+++ b/roles/supervisorctl/library/supervisorctl2.py
@@ -14,7 +14,7 @@ from supervisor.xmlrpc import SupervisorTransport
 DOCUMENTATION = """
 ---
 module: supervisorctl
-version: "1.1"
+version: "2.1"
 short_description:  Manage supervisord managed services
 description:
     - Controls supervisor managed services on remote hosts.
@@ -52,13 +52,13 @@ options:
 
 EXAMPLES = """
 # Example action to start service httpd, if not running
-- supervisorctl: name=httpd state=started
+- supervisorctl2: name=httpd state=started
 # Example action to stop service httpd, if running
-- supervisorctl: name=httpd state=stopped
+- supervisorctl2: name=httpd state=stopped
 # Example action to restart service httpd, in all cases
-- supervisorctl: name=httpd state=restarted
+- supervisorctl2: name=httpd state=restarted
 # Example action to restart the supervisor group programs under the name servu
-- supervisorctl: group=servu state=restarted
+- supervisorctl2: group=servu state=restarted
 """
 
 DEFAULT_URL = 'unix:///var/run/supervisor.sock'

--- a/roles/zclient/tasks/main.yml
+++ b/roles/zclient/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: restart zclients
   when: "{{ not supervisor_conf_for_zclients|changed }}"
   become: yes
-  supervisorctl:
+  supervisorctl2:
     name: "{{ item }}"
     state: restarted
   with_items: "[{% for i in range(0, hostvars[inventory_hostname].zclient_count|default(1), 1) %}'{{ 'zclient_instance{}'.format(i) }}',{% endfor %}]"

--- a/roles/zclient/tasks/main.yml
+++ b/roles/zclient/tasks/main.yml
@@ -10,6 +10,7 @@
   notify:
     - reload supervisord
 
+# TODO (01-Feb-12017) Use the 'supervisorctl' module's group feature
 - name: restart zclients
   when: "{{ not supervisor_conf_for_zclients|changed }}"
   become: yes

--- a/roles/zeo/tasks/main.yml
+++ b/roles/zeo/tasks/main.yml
@@ -18,6 +18,6 @@
 - name: restart zeo
   when: "{{ not supervisor_conf_for_zeo|changed }}"
   become: yes
-  supervisorctl:
+  supervisorctl2:
     name: zeo
     state: restarted


### PR DESCRIPTION
Added support for changing the state (stopped, started, restarted) of supervisor grouped processes.

I've also renamed the module so that it doesn't conflict with the built-in ansible module of the same name. (I don't recall it existing when I created this module, but it must have.)

Ansible's supervisorctl module conflicts with ours. Furthermore, ansible doesn't load our module even though the supervisorctl role is a dependency of the major role. But for some unknown reason it will load our module if the supervisorctl role is mentioned at the play level rather than only as a dependency of a role. But this only works if you use the role once within a series of plays. I think I see a place full of spaghetti. Yeah, ansible rocks... :1st_place_medal: 