### PR TITLE
Include cnx-easybake in the publishing install

### DIFF
--- a/environments/dev/files/publishing-requirements.txt
+++ b/environments/dev/files/publishing-requirements.txt
@@ -1,7 +1,4 @@
--e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
--e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
--e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
--e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
+-r archive-requirements.txt
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing

--- a/environments/dev/files/publishing-requirements.txt
+++ b/environments/dev/files/publishing-requirements.txt
@@ -1,5 +1,8 @@
 -r archive-requirements.txt
 
+-e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
+-e git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
+
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 

--- a/environments/tea/files/publishing-requirements.txt
+++ b/environments/tea/files/publishing-requirements.txt
@@ -1,7 +1,4 @@
--e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
--e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
--e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
--e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
+-r archive-requirements.txt
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing

--- a/environments/tea/files/publishing-requirements.txt
+++ b/environments/tea/files/publishing-requirements.txt
@@ -1,5 +1,8 @@
 -r archive-requirements.txt
 
+-e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
+-e git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
+
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 


### PR DESCRIPTION
This simply includes the the cnx-easybake logic in the publishing install so that content collation can be done on the server.