### PR TITLE
Add memcached as a dependency of the pdf_gen role

### DIFF
--- a/roles/pdf_gen/meta/main.yml
+++ b/roles/pdf_gen/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - supervisord
+  - memcached


### PR DESCRIPTION
This will install memcached on the server so that the oer.exports logic can
take advantage of cached content.