### PR TITLE
move cnx-db to repo based install for dev environment

### DIFF
--- a/environments/dev/files/archive-requirements.txt
+++ b/environments/dev/files/archive-requirements.txt
@@ -2,6 +2,7 @@
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
+-e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
 db-migrator==0.1.4
 cnx-db>=0.2


### PR DESCRIPTION
Since cnx-db is now tightly coupled to cnx-archive and cnx-publishing, deploy in dev environment from repo. We'll still release for staging/qa/production ( and should release the others, too)