### PR TITLE
Make the archive postgresql role a superuser on first run

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -28,10 +28,19 @@
   hosts:
     - database
   tasks:
+    - name: check for the database
+      become: yes
+      become_user: postgres
+      command: psql -U postgres --tuples-only -c "select true from pg_database where datname='{{ archive_db_name }}'"
+      register: archive_db_exists
     - include: tasks/create_db_user.yml
       vars:
         db_user: "{{ archive_db_user }}"
         db_password: "{{ archive_db_password }}"
+        # FIXME (8-Mar-12017) New databases currently require the user to have
+        #       superuser privileges. This is only required for database
+        #       initialization. This is to be correct in cnx-db.
+        role_attr_flags: "{{ 't' in archive_db_exists.stdout and 'CREATEDB,NOSUPERUSER' or 'SUPERUSER' }}"
     - include: tasks/create_db.yml
       vars:
         db_owner: "{{ archive_db_user }}"


### PR DESCRIPTION
This hopefully takes the initial fail out of a provisioning task.
We do this rather than simply apply the superuser privileges because
we don't want to give the role superuser on the production data.
It's still possible to run into a provisioning problem the database
and publishing aren't setup at the same time.

In the short-term there isn't much to do about this.
A fix to the needed permissions will be made in cnx-db.
At that time this fix can be removed.