### PR TITLE
quoting values in app.ini breaks them

### DIFF
--- a/roles/publishing/templates/etc/cnx/publishing/app.ini
+++ b/roles/publishing/templates/etc/cnx/publishing/app.ini
@@ -56,12 +56,12 @@ openstax_accounts.callback_path = /callback
 openstax_accounts.logout_path = /logout
 openstax_accounts.logout_redirects_to = /a/
 
-embeddables.terp_url_template =  'https://{{ tutor_domain }}/terp/{itemCode}/quiz_start'
-embeddables.exercise.url_template = 'https://{{ exercises_domain }}/api/exercises?q=tag:{itemCode}'
-embeddables.exercise.match = '#ost/api/ex/'
-embeddables.exercise.token = '{{ exercises_token }}'
+embeddables.terp_url_template =  https://{{ tutor_domain }}/terp/{itemCode}/quiz_start
+embeddables.exercise.url_template = https://{{ exercises_domain }}/api/exercises?q=tag:{itemCode}
+embeddables.exercise.match = #ost/api/ex/
+embeddables.exercise.token = {{ exercises_token }}
 
-mathmlcloud.url = 'http://mathmlcloud.cnx.org:1337/equation'
+mathmlcloud.url = http://mathmlcloud.cnx.org:1337/equation
 
 
 ###


### PR DESCRIPTION
Having quotes around these values (silently) breaks exercise fetching and TeX math conversion. Oops.