### PR TITLE
reduce HSTS level to what we can handle for now

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -13,7 +13,7 @@
         bind *:80
         bind *:443 ssl crt /etc/ssl/certs/{{ frontend_domain }}.pem
 
-        http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;"
+        http-response set-header Strict-Transport-Security "max-age=16000000"
         http-request set-header X-Secure true if { ssl_fc }
         http-request set-header X-Forwarded-Proto https if { ssl_fc }
 


### PR DESCRIPTION
This brings cnx.org in line with what we've serving for openstax.org, and remove the requirement that all subdomains (like dev.cnx.org or other test and development machines) be served exclusively over https