### PR TITLE
Remove the postgres install for zope machines

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -10,18 +10,6 @@
 
 - name: install postgres database
   hosts:
-    # FIXME The zclient group's rhaptos site creation requires a local database.
-    #       This is only required during provisioning. =/
-    - zclient
-  roles:
-    - postgres
-  tags:
-    - database
-    - legacy_be
-    - be
-
-- name: install postgres database
-  hosts:
     - database
     - replicant
   roles:


### PR DESCRIPTION
We previously installed postgres on the machine used by zclients so that
the site creation could complete. We did this because the site creation
needs an empty database in order to successfully run. Later we transitioned
to creating a dummy database on the database server for it to use.
However, we forgot to remove the postgres install from the previous solution.
This takes care of removing that previous solution.