### PR TITLE
Fix archive db role permissions

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -22,19 +22,18 @@
   hosts:
     - database
   tasks:
-    - name: check for the database
-      become: yes
-      become_user: postgres
-      command: psql -U postgres --tuples-only -c "select true from pg_database where datname='{{ archive_db_name }}'"
-      register: archive_db_exists
     - include: tasks/create_db_user.yml
       vars:
         db_user: "{{ archive_db_user }}"
         db_password: "{{ archive_db_password }}"
-        # FIXME (8-Mar-12017) New databases currently require the user to have
-        #       superuser privileges. This is only required for database
-        #       initialization. This is to be correct in cnx-db.
-        role_attr_flags: "{{ 't' in archive_db_exists.stdout and 'CREATEDB,NOSUPERUSER' or 'SUPERUSER' }}"
+        # FIXME (8-Mar-12017) db-role-perms:
+        #       New databases and migrations currently
+        #       require the user to have superuser privileges.
+        #       This is only required for database
+        #       initialization and migrations.
+        #       This is to be correct in cnx-db and db-migrator.
+        #       In the mean time use xxx_archive_db_user_role_attr_flags.
+        role_attr_flags: "{{ xxx_archive_db_user_role_attr_flags|default('CREATEDB,NOSUPERUSER') }}"
     - include: tasks/create_db.yml
       vars:
         db_owner: "{{ archive_db_user }}"

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -6,6 +6,8 @@ archive_db_user: "{{ vault_archive_db_user }}"
 archive_db_password: "{{ vault_archive_db_password }}"
 archive_db_host: dev00.cnx.org
 archive_db_port: 5432
+# FIXME (10-Apr-12017) db-role-perms: assign the role superuser privileges.
+xxx_archive_db_user_role_attr_flags: 'SUPERUSER'
 
 authoring_db_name: "{{ vault_authoring_db_name }}"
 authoring_db_user: "{{ vault_authoring_db_user }}"


### PR DESCRIPTION
This temporarily allows the user running ansible to set the roles
privileges in order to complete an operations. For example, the user
would assign xxx_archive_db_user_role_attr_flags: 'SUPERUSER' during
server provisioning to allow the creation of the database (specifically
for the creation of extensions).