### PR TITLE
Allow for the overriding of the haproxy zcluster port

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -15,6 +15,7 @@ default_zclient_base_port: 8280
 role_attr_flags: CREATEDB,NOSUPERUSER
 
 default_replicator_db_user: replicator
+default_haproxy_zcluster_port: 8888
 
 # postgres_connections:
 #   - name: <human readable name>

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -27,7 +27,7 @@ acl block {
 # haproxy load balancing for zope
 backend legacy_frontend {
 .host = "{{ hostvars[groups.legacy_frontend[0]].ansible_default_ipv4.address }}";
-.port = "{{ haproxy_port|default('8888') }}";
+.port = "{{ haproxy_zcluster_port|default(default_haproxy_zcluster_port) }}";
 .connect_timeout = 0.4s;
 .first_byte_timeout = 1200s;
 .between_bytes_timeout = 600s;

--- a/roles/zclient_load_balancer/tasks/main.yml
+++ b/roles/zclient_load_balancer/tasks/main.yml
@@ -10,7 +10,7 @@
     insertafter: EOF
     block: |
       frontend zcluster
-        bind :8888
+        bind :{{ haproxy_zcluster_port|default(default_haproxy_zcluster_port) }}
         default_backend zclients
 
       # Load balancing over the zope instances


### PR DESCRIPTION
The default port conflicts with the default port for pdf_gen. So this provides a way to change the port for haproxy's zcluster.