### PR TITLE
Fix the definition name value use within the varnish config file

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -58,7 +58,7 @@ probe archive_probe {
 {% for host in groups.archive %}
 {% for i in range(0, hostvars[host].archive_count|default(1), 1) %}
 {% set ip_addr = hostvars[host].ansible_default_ipv4.address %}
-{% set name = host.split('.')[-1]|replace('-','_') %}
+{% set name = host.split('.')[0]|replace('-','_') %}
 {% set backend_name = '{}_archive{}'.format(name, i) %}
 backend {{ backend_name }} {
 .host = "{{ ip_addr }}";
@@ -80,7 +80,7 @@ probe publishing_probe {
 {% for host in groups.publishing %}
 {% for i in range(0, hostvars[host].publishing_count|default(1), 1) %}
 {% set ip_addr = hostvars[host].ansible_default_ipv4.address %}
-{% set name = host.split('.')[-1]|replace('-','_') %}
+{% set name = host.split('.')[0]|replace('-','_') %}
 {% set backend_name = '{}_publishing{}'.format(name, i) %}
 backend {{ backend_name }} {
 .host = "{{ ip_addr }}";


### PR DESCRIPTION
If the hostname is `des00.cnx.org` this change fixes it so that
the `des00` portion is used rather than `org`.