### PR TITLE
Conditional iptables usage

### DIFF
--- a/iptables.yml
+++ b/iptables.yml
@@ -4,6 +4,9 @@
   gather_facts: no
   roles:
     - role: iptables
+      when:
+        - install_firewall is defined
+        - install_firewall|bool
       tags:
         - iptables
         - firewall

--- a/roles/iptables/templates/etc/iptables
+++ b/roles/iptables/templates/etc/iptables
@@ -1,4 +1,4 @@
-# jinja2: lstrip_blocks: “True”
+#jinja2: lstrip_blocks: "True"
 {#
 # -*- mode: jinja -*
 # vi: set ft=jinja syntax=jinja :
@@ -42,6 +42,9 @@
 {% endif %}
 {% if (inventory_hostname in groups.database or inventory_hostname in groups.replicant) -%}
     -A INPUT -p tcp --dport 5432 -m comment --comment "allowed Postgres client ports" -j  ACCEPT
+{% endif %}
+{% if (inventory_hostname in groups.legacy_frontend -%}
+    -A INPUT -p tcp --dport {{ haproxy_zcluster_port|default(default_haproxy_zcluster_port) }} -m comment --comment "allow haproxy zcluster port" -j  ACCEPT
 {% endif %}
 -A INPUT -j LOGREJECT
 -A LOGREJECT -m comment --comment "Rejection log" -j LOG --log-prefix "FIREWALL-REJECTED: "


### PR DESCRIPTION
This enables us to conditionally use the iptables playbook.

This also includes a fix to punch a hole in the legacy_frontend server to allow access to the zcluster haproxy component. The only thing this really gives us is a way to access haproxy-status, because the service itself is only used local to the machine it's deployed on.