### PR TITLE
add vars.sh files to hold shell vars for script use

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -112,14 +112,14 @@
 - name: render configuration
   become: yes
   template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: 0744
+    src: "{{ item }}"
+    dest: "/{{ item }}"
+    mode: 0644
     owner: root
     group: root
   with_items:
-    - {src: "etc/cnx/archive/app.ini",
-       dest: "/etc/cnx/archive/app.ini"}
+    - "etc/cnx/archive/app.ini"
+    - "etc/cnx/archive/vars.sh"
   notify:
     - restart archive
 

--- a/roles/archive/templates/etc/cnx/archive/vars.sh
+++ b/roles/archive/templates/etc/cnx/archive/vars.sh
@@ -1,0 +1,12 @@
+# this is a shell script which can be sourced into other scripts
+# to provide access to configuration values specific to this host
+
+archive_db_name="{{ vault_archive_db_name }}"
+archive_db_user="{{ vault_archive_db_user }}"
+archive_db_host="{{ archive_db_host }}"
+archive_db_port="{{ archive_db_port }}"
+archive_host="{{ archive_host }}"
+archive_base_port="{{ default_archive_base_port }}"
+archive_count="{{ archive_count }}"
+# NOTE: some of the hosts in this list may point to a different db_host
+archive_hosts_list=( "{{ groups.archive | join(" ") }}" )

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -116,16 +116,15 @@
 - name: render configuration
   become: yes
   template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
-    mode: 0744
+    src: "{{ item }}"
+    dest: "/{{ item }}"
+    mode: 0644
     owner: root
     group: root
   with_items:
-    - {src: "etc/cnx/publishing/app.ini",
-       dest: "/etc/cnx/publishing/app.ini"}
-    - {src: "etc/cnx/publishing/logging.yaml",
-       dest: "/etc/cnx/publishing/logging.yaml"}
+    - "etc/cnx/publishing/app.ini"
+    - "etc/cnx/publishing/logging.yaml"
+    - "etc/cnx/publishing/vars.sh"
   notify:
     - restart publishing
 

--- a/roles/publishing/templates/etc/cnx/publishing/vars.sh
+++ b/roles/publishing/templates/etc/cnx/publishing/vars.sh
@@ -1,0 +1,14 @@
+# this is a shell script which can be sourced into other scripts
+# to provide access to configuration values specific to this host
+
+publishing_host="{{ publishing_host }}"
+publishing_port="{{ publishing_port }}"
+publishing_base_port="{{ publishing_base_port }}"
+publishing_count="{{ publishing_count }}"
+# NOTE: some of the hosts in this list may point to a different db_host
+publishing_hosts_list=( "{{ groups.publishing | join(" ") }}" )
+
+archive_db_name="{{ vault_archive_db_name }}"
+archive_db_user="{{ vault_archive_db_user }}"
+archive_db_host="{{ archive_db_host }}"
+archive_db_port="{{ archive_db_port }}"


### PR DESCRIPTION
I changed the way the with_items works to reduce repetition and changed the file perms from 744 to 644 since I didn't think they need to be executable.

The use of the variables in the archive-restart script will come in a separate PR.