### PR TITLE
Remove the now invalid {publishing,archive}_host variables

### DIFF
--- a/roles/archive/templates/etc/cnx/archive/vars.sh
+++ b/roles/archive/templates/etc/cnx/archive/vars.sh
@@ -5,7 +5,6 @@ archive_db_name="{{ vault_archive_db_name }}"
 archive_db_user="{{ vault_archive_db_user }}"
 archive_db_host="{{ archive_db_host }}"
 archive_db_port="{{ archive_db_port }}"
-archive_host="{{ archive_host }}"
 archive_base_port="{{ default_archive_base_port }}"
 archive_count="{{ archive_count }}"
 # NOTE: some of the hosts in this list may point to a different db_host

--- a/roles/publishing/templates/etc/cnx/publishing/vars.sh
+++ b/roles/publishing/templates/etc/cnx/publishing/vars.sh
@@ -1,7 +1,6 @@
 # this is a shell script which can be sourced into other scripts
 # to provide access to configuration values specific to this host
 
-publishing_host="{{ publishing_host }}"
 publishing_port="{{ publishing_port }}"
 publishing_base_port="{{ publishing_base_port }}"
 publishing_count="{{ publishing_count }}"


### PR DESCRIPTION
These have been removed because there is no longer a singular host or
service that runs publishing or archive.