### PR TITLE
Fix to use a local connection rather then the local host definition

### DIFF
--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -9,7 +9,8 @@
   tasks: []
 
 - name: generate a self-signed certificate
-  hosts: local
+  hosts: 127.0.0.1
+  connection: local
   vars:
     cert_password: "password"
     cert_domain: "*.{{ frontend_domain }}"


### PR DESCRIPTION
The `local` host definition was removed several changesets ago. This one must have slipped through. This removes it in favor of using the localhost host and a local connection.