### PR TITLE
Make CNXML DTD pkg installs a dependent role

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -23,18 +23,6 @@
 - include: database.yml
 - include: broker.yml
 
-- name: install cnxml dtd pkgs
-  hosts:
-    - database
-    - replicant
-    - zeo
-    - zclient
-    - pdf_gen
-  tasks:
-    - include: tasks/install_cnxml_dtd.yml
-  tags:
-    - install-cnxml-dtd-pkgs
-
 # +++
 # Applications
 # +++

--- a/roles/cnx_database/meta/main.yml
+++ b/roles/cnx_database/meta/main.yml
@@ -3,3 +3,4 @@
 dependencies:
   - postgres
   - python2
+  - dtd_files

--- a/roles/dtd_files/tasks/main.yml
+++ b/roles/dtd_files/tasks/main.yml
@@ -6,23 +6,31 @@
   apt:
     name: apt-transport-https
     state: present
+  tags:
+    - install-cnxml-dtd-pkgs
 
 - name: configure apt to not verify the cnx repo
   become: yes
   copy:
     src: etc/apt/apt.conf.d/90packages-cnx-org
     dest: "/etc/apt/apt.conf.d/90packages-cnx-org"
+  tags:
+    - install-cnxml-dtd-pkgs
 
 - name: add cnx apt repo
   become: yes
   apt_repository:
     repo: "deb http://packages.cnx.org/ deb/"
     state: present
+  tags:
+    - install-cnxml-dtd-pkgs
 
 - name: update apt cache
   become: yes
   apt:
     update_cache: yes
+  tags:
+    - install-cnxml-dtd-pkgs
 
 - name: install connexions pkgs
   become: yes
@@ -38,3 +46,5 @@
     - connexions-bibtexml-1.0
     - connexions-mathml-2.0
     - connexions-collxml-1.0
+  tags:
+    - install-cnxml-dtd-pkgs

--- a/roles/zope_common/meta/main.yml
+++ b/roles/zope_common/meta/main.yml
@@ -3,3 +3,4 @@
 dependencies:
   - _pgdg_repo
   - python24
+  - dtd_files


### PR DESCRIPTION
Instead of having this as it's own task make it a dependency of the roles that depend on this info.

This allows for more precision deployments via the role-based playbooks (e.g. `database.yml`).