### PR TITLE
Update VM environment so it can set up a development environment

### DIFF
--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -23,7 +23,8 @@ authoring_db_port: 5432
 # where a memcached instance is running.
 memcached_hosts: localhost
 
-varnish_port: 8080
+varnish_port: 8990
+haproxy_zcluster_port: 8998
 
 archive_host: archive.local.cnx.org
 archive_port: 6789

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -27,11 +27,8 @@ varnish_port: 8990
 haproxy_zcluster_port: 8998
 
 archive_host: archive.local.cnx.org
-archive_port: 6789
 publishing_host: archive.local.cnx.org
-publishing_port: 6543
 authoring_host: authoring.local.cnx.org
-authoring_port: 6420
 zclient_base_port: 8280
 
 zope_domain: legacy.local.cnx.org

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -54,3 +54,5 @@ nfs_server_for_varnish_logs: local.cnx.org
 webview_version: master
 
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
+
+venvs_owner: "{{ ansible_user_id }}"

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -6,6 +6,7 @@ archive_db_user: cnxarchive
 archive_db_password: cnxarchive
 archive_db_host: localhost
 archive_db_port: 5432
+xxx_archive_db_user_role_attr_flags: 'SUPERUSER'
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing
@@ -47,5 +48,9 @@ exercises_token: "somekindoftoken"
 
 nfs_server_for_files1: local.cnx.org
 nfs_server_for_files2: local.cnx.org
+nfs_server_for_specials: local.cnx.org
+nfs_server_for_varnish_logs: local.cnx.org
 
 webview_version: master
+
+princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -44,6 +44,7 @@ exercises_domain: exercises.openstax.org
 accounts_consumer_token: 
 accounts_consumer_secret: 
 accounts_disable_verify_ssl: yes
+accounts_stub: yes
 
 exercises_token: "somekindoftoken"
 

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -12,6 +12,9 @@ local.cnx.org
 [database:children]
 local.cnx.org
 
+[replicant:children]
+# None, because single-machine install
+
 [broker:children]
 local.cnx.org
 
@@ -65,6 +68,8 @@ zclient
 pdf_gen
 
 [nfs_connected:children]
+archive
+publishing
 legacy_frontend
 publishing_worker
 frontend

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -2,7 +2,8 @@
 local.cnx.org
 
 [zope.local.cnx.org]
-zope.local.cnx.org
+# If zope is on a different machine, use zope.local.cnx.org
+local.cnx.org
 
 # Grouped Hosts
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -41,11 +41,8 @@ default_publishing_broker_vhost: /publishing
 # authoring_db_port: 5432
 
 # archive_host: 0.0.0.0
-# archive_port: 6789
 # publishing_host: 0.0.0.0
-# publishing_port: 6543
 # authoring_host: 0.0.0.0
-# authoring_port: 8080
 
 # zope_domain: legacy.cnx.org
 # arclishing_domain: archive.cnx.org

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -41,7 +41,7 @@
     path: "/var/cnx/venvs"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of venvs directory
   become: yes
@@ -49,11 +49,11 @@
     path: "/var/cnx/venvs"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: create the archive virtualenv
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name: pip
     virtualenv: "/var/cnx/venvs/archive"
@@ -92,7 +92,7 @@
 
 - name: install archive
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"

--- a/roles/archive/templates/etc/cnx/archive/vars.sh
+++ b/roles/archive/templates/etc/cnx/archive/vars.sh
@@ -1,8 +1,8 @@
 # this is a shell script which can be sourced into other scripts
 # to provide access to configuration values specific to this host
 
-archive_db_name="{{ vault_archive_db_name }}"
-archive_db_user="{{ vault_archive_db_user }}"
+archive_db_name="{{ archive_db_name }}"
+archive_db_user="{{ archive_db_user }}"
 archive_db_host="{{ archive_db_host }}"
 archive_db_port="{{ archive_db_port }}"
 archive_base_port="{{ archive_base_port|default(default_archive_base_port) }}"

--- a/roles/authoring/tasks/main.yml
+++ b/roles/authoring/tasks/main.yml
@@ -40,7 +40,7 @@
     path: "/var/cnx/venvs"
     state: directory
     mode: 0755
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: set the owner of venvs directory
   become: yes
@@ -48,11 +48,11 @@
     path: "/var/cnx/venvs"
     state: directory
     recurse: yes
-    owner: www-data
+    owner: "{{ venvs_owner|default('www-data') }}"
 
 - name: create the authoring virtualenv
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     name: pip
     virtualenv: "/var/cnx/venvs/authoring"
@@ -91,7 +91,7 @@
 
 - name: install authoring
   become: yes
-  become_user: www-data
+  become_user: "{{ venvs_owner|default('www-data') }}"
   pip:
     requirements: "/var/lib/cnx/authoring-requirements.txt"
     virtualenv: "/var/cnx/venvs/authoring"

--- a/roles/authoring/templates/etc/cnx/authoring/app.ini
+++ b/roles/authoring/templates/etc/cnx/authoring/app.ini
@@ -35,6 +35,21 @@ current-license-urls =
 # size limit of file upload in MB
 authoring.file_upload.limit = 50
 
+{% if accounts_stub|default(false) %}
+openstax_accounts.stub = true
+openstax_accounts.stub.message_writer = log
+openstax_accounts.stub.users =
+  user1,password
+  user2,password
+  Rasmus1975,password
+  charrose,charrose
+  frahablar,frahablar
+  impicky,impicky
+  marknewlyn,marknewlyn
+  ream,ream
+  rings,rings
+  sarblyth,sarblyth
+{% endif %}
 {% if (accounts_disable_verify_ssl is defined and accounts_disable_verify_ssl)
       or inventory_dir.endswith('environments/local') %}
 openstax_accounts.disable_verify_ssl = true

--- a/roles/publishing_common/templates/etc/cnx/publishing/app.ini
+++ b/roles/publishing_common/templates/etc/cnx/publishing/app.ini
@@ -38,6 +38,21 @@ api-key-authnz =
   developer,g:publishers
   4e8,loading-zone,
 
+{% if accounts_stub|default(False) %}
+openstax_accounts.stub = true
+openstax_accounts.stub.message_writer = log
+openstax_accounts.stub.users =
+  user1,password
+  user2,password
+  Rasmus1975,password
+  charrose,charrose
+  frahablar,frahablar
+  impicky,impicky
+  marknewlyn,marknewlyn
+  ream,ream
+  rings,rings
+  sarblyth,sarblyth
+{% endif %}
 {% if (accounts_disable_verify_ssl is defined and accounts_disable_verify_ssl)
       or inventory_dir.endswith('environments/local') %}
 openstax_accounts.disable_verify_ssl = true

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -158,6 +158,14 @@ sub vcl_recv {
         return (pass);
     }
 
+{% if accounts_stub|default(False) %}
+    # cnx rewrite stub login form
+    if (req.url ~ "^/stub-login-form") {
+        set req.backend_hint = publishing_cluster.backend(req.http.cookie);
+        return (pass);
+    }
+
+{% endif %}
     # cnx rewrite archive
     if (req.url ~ "^/a/") {
         set req.backend_hint = publishing_cluster.backend(req.http.cookie);


### PR DESCRIPTION
I added a new variable called `venvs_owner`.  It is the owner of the `/var/cnx/venvs` directories.  I added it so it is possible to set the ssh user as the owner instead of www-data, but the default is still www-data if the variable is not set.  Having the ssh user as the owner in the VM environment makes it a lot easier for development if I need to change the code.

The other change is the one pumazi commented on: changing `vault_archive_db_name` and `vault_archive_db_user` to `archive_db_name` and `archive_db_user`.  The `vault_` variables should only be used in `group_vars/`, not directly in any templates or playbooks.