### PR TITLE
Set haproxy zcluster ports to 8998 in QA

### DIFF
--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -24,6 +24,7 @@ authoring_db_port: 5432
 memcached_hosts: localhost
 
 varnish_port: 8990
+haproxy_zcluster_port: 8998
 
 archive_host: "{{ _host_prefix }}.cnx.org"
 publishing_host: "{{ _host_prefix }}.cnx.org"


### PR DESCRIPTION
The default haproxy zcluster port, 8888, conflicts with the pdf_gen
instance.  This is a problem on QA because everything is on one host.