### PR TITLE
Restart varnish to ensure it uses the correct port

### DIFF
--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -51,3 +51,11 @@
     src: "etc/cron.daily/copy_varnish_logs"
     dest: "/etc/cron.daily/copy_varnish_logs"
     mode: 0755
+
+# +++
+# Always Restart Varnish (to ensure Varnish is using the correct port)
+# +++
+- name: always restart varnish
+  command: /bin/true
+  notify:
+    - restart varnish


### PR DESCRIPTION
Without this step, varnish was using the default port (6081) instead of
the one in /etc/default/varnish.

Close #350