### PR TITLE
Set the zope clock server to use 127.0.0.1 as host

### DIFF
--- a/roles/zope_common/templates/var/lib/cnx/cnx-buildout/ansible.cfg
+++ b/roles/zope_common/templates/var/lib/cnx/cnx-buildout/ansible.cfg
@@ -52,6 +52,7 @@ zope-conf-additional =
     <clock-server>
         method /${shared:portal-name}/queue_tool/clockTick
         period 3
+        host 127.0.0.1
         user
         password 
     </clock-server>


### PR DESCRIPTION
On QA, the queue_tool was not processing any jobs.  A clock server was
set up to hit the queue_tool clockTick URL every 3 seconds, but
according to /var/lib/cnx/cnx-buildout/var/log/pdf_gen-Z2.log, the URL
returns 404:

127.0.0.1 - (-) Anonymous [01/Aug/2017:16:33:37 -0500] "GET /plone/queue_tool/clockTick HTTP/1.0" 404 0 "" "Zope Clock Server Client"

However I was able to go to the URL using wget:

```
karen@qa00:/var/lib/cnx/cnx-buildout$ wget -O -
http://127.0.0.1:8888/plone/queue_tool/clockTick
--2017-08-01 16:36:56-- http://127.0.0.1:8888/plone/queue_tool/clockTick
Connecting to 127.0.0.1:8888... connected.
HTTP request sent, awaiting response... 204 No Content
2017-08-01 16:36:56 (0.00 B/s) - written to stdout [0]
```

Clock server uses "socket.gethostname()" to determine the host if it is
not specified.  On QA, it is "qa00.cnx.org".  It appears to be the
reason why we are getting 404.

This change sets the host to "127.0.0.1" for clock server requests.  I
have tested this on QA and it appears to fix the problem.