### PR TITLE
Fix duplicate minor versions on QA and TEA

### DIFF
--- a/hotfixes/20170804_remove_duplicate_minor_versions.yml
+++ b/hotfixes/20170804_remove_duplicate_minor_versions.yml
@@ -1,0 +1,20 @@
+---
+# Used to fix multiple copies of the same minor versions on QA and TEA when
+# more than one page was published while the book was baking.
+
+- name: fix multiple copies of the same minor versions on QA and TEA
+  hosts: publishing
+  tasks:
+    - name: download python script to remove duplicate minor versions
+      get_url:
+        url: "https://raw.githubusercontent.com/Connexions/devops/master/scripts/remove_duplicate_minor_version_books.py"
+        dest: "/tmp"
+
+    - name: run python script to remove duplicate minor versions
+      shell: "/var/cnx/venvs/publishing/bin/python /tmp/remove_duplicate_minor_version_books.py -d 'dbname={{ archive_db_name }} user={{ archive_db_user }} password={{ archive_db_password }} host={{ archive_db_host }} port={{ archive_db_port }}'"
+
+- name: disable update_default_modules_stateid trigger
+  hosts: database
+  tasks:
+    - name: disable update_default_modules_stateid trigger
+      shell: "echo 'ALTER TABLE modules DISABLE TRIGGER update_default_modules_stateid;' | psql 'dbname={{ archive_db_name }} user={{ archive_db_user }} password={{ archive_db_password }} host={{ archive_db_host }} port={{ archive_db_port }}'"


### PR DESCRIPTION
When a page is published while the book is baking, we end up with two
copies of the book with exactly the same minor version.  While the code
for this is being fixed on cnx-archive, the data still needs to be
fixed.  This also includes temporarily disabling a trigger which fixes
the multiple minor versions problem, by updating the latest modules
table even when the book has not finished baking.