### PR TITLE
Use pyramid_sawing for archive logs

### DIFF
--- a/environments/prod/files/archive-requirements.txt
+++ b/environments/prod/files/archive-requirements.txt
@@ -17,6 +17,7 @@ psycopg2==2.5.4
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
+pyramid_sawing==1.1.2
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -22,6 +22,7 @@ psycopg2==2.5.4
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
+pyramid_sawing==1.1.2
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/staging/files/archive-requirements.txt
+++ b/environments/staging/files/archive-requirements.txt
@@ -17,6 +17,7 @@ psycopg2==2.5.4
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
+pyramid_sawing==1.1.2
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -22,6 +22,7 @@ psycopg2==2.5.4
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
+pyramid_sawing==1.1.2
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -121,6 +121,7 @@
     group: root
   with_items:
     - "etc/cnx/archive/app.ini"
+    - "etc/cnx/archive/logging.yaml"
     - "etc/cnx/archive/vars.sh"
   notify:
     - restart archive

--- a/roles/archive/templates/etc/cnx/archive/app.ini
+++ b/roles/archive/templates/etc/cnx/archive/app.ini
@@ -19,11 +19,11 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
-# pyramid.includes =
-#     pyramid_sawing
+pyramid.includes =
+    pyramid_sawing
 
-# pyramid_sawing.file = %(here)s/logging.yaml
-# pyramid_sawing.transit_logging.enabled? = yes
+pyramid_sawing.file = %(here)s/logging.yaml
+pyramid_sawing.transit_logging.enabled? = yes
 
 db-connection-string = dbname={{ archive_db_name }} user={{ archive_db_user }} password={{ archive_db_password }} host={{ archive_db_host }} port={{ archive_db_port }}
 # a list of memcache servers separated by whitespace

--- a/roles/archive/templates/etc/cnx/archive/logging.yaml
+++ b/roles/archive/templates/etc/cnx/archive/logging.yaml
@@ -1,0 +1,66 @@
+###
+# logging configuration
+###
+version: 1
+
+formatters:
+  generic:
+    format    : '%(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s'
+  papertrail:
+    # requires filters [context]
+    format    : '%(asctime)s %(hostname)s publishing %(message)s'
+    datefmt   : '%Y-%m-%dT%H:%M:%S'
+  apache_style:
+    # requires filters [environ]
+    format    : '%(REMOTE_ADDR)s - %(REMOTE_USER)s [%(asctime)s] "%(REQUEST_METHOD)s %(REQUEST_URI)s %(HTTP_VERSION)s" %(status)s %(bytes)s "%(HTTP_REFERER)s" "%(HTTP_USER_AGENT)s"'
+    datefmt   : '%d/%b/%Y:%H:%M:%S'
+filters:
+  context:
+    ()        : pyramid_sawing.filters.ContextFilter
+  environ:
+    ()        : pyramid_sawing.filters.EnvironFilter
+handlers:
+  console:
+    class     : logging.StreamHandler
+    level     : NOTSET
+    formatter : generic
+    stream    : 'ext://sys.stdout'
+  # syslog:
+  #   # Streams directly to papertrailapp.com.
+  #   # You'll need to change the host and port in order to use this.
+  #   class     : logging.handlers.SysLogHandler
+  #   level     : DEBUG
+  #   formatter : papertrail
+  #   # Note, the environ filter is automatically included by pyramid_sawing.
+  #   filters   : [context, environ]
+  #   address   : ['<host>.papertrailapp.com', 11111]
+  transit:
+    # Streams to standard out (STDOUT) using the apache-style formatter.
+    class     : logging.StreamHandler
+    level     : NOTSET
+    formatter : apache_style
+    stream    : 'ext://sys.stdout'
+loggers:
+  cnxpublishing:
+    # This is our pyramid application logger.
+    level     : DEBUG
+    handlers  : [console]
+    propagate : 0
+  post_publication:
+    level     : DEBUG
+    handlers  : [console]
+    propagate : 0
+  transit_logger:
+    # This is the transit logger in pyramid_sawing.
+    level     : INFO
+    handlers  : [transit]
+    propagate : 0
+  waitress:
+    # The logger for the waitress http server.
+    # Note, that this logger is responsible for reporting 500 errors
+    # with the traceback.
+    level     : DEBUG
+    propagate : 1
+root:
+  level       : NOTSET
+  handlers    : [console]


### PR DESCRIPTION
This logs all requests and exceptions to archive in stdout with
timestamps.

For example:

```
192.168.122.250 - - [22/Aug/2017:12:19:29] "GET http://192.168.122.250/ HTTP/1.1" 200 OK 0 "-" "-"
2017-08-22 12:19:31,436 ERROR [waitress][waitress] Exception when serving /feeds/recent.rss
Traceback (most recent call last):
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/waitress/channel.py", line 338, in service
```