### PR TITLE
Run daemon-reload after adding varnish config files

### DIFF
--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -37,6 +37,7 @@
     group: "{{ item.group|default('root') }}"
   with_items: "{{ varnish['templates'] }}"
   notify:
+    - restart daemon tools
     - restart varnish
   tags:
     - varnish-configure


### PR DESCRIPTION
Varnish was still running on the default port 6081 when the main
playbook finished running.  It was not using the `varnish_port`
variable even though `/etc/default/varnish` has the correct port.

When adding or changing systemd unit files, we need to run
`systemctl daemon-reload` for services to start correctly.

Close #350