### PR TITLE
Redirect specials static file requests to https

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -21,6 +21,8 @@
         acl is_arclishing hdr(host) -i {{ arclishing_domain }}
         acl is_cnxorg hdr(host) -i {{ frontend_domain }}
         acl has_www hdr_beg(host) -i www 
+        acl is_specials path_beg /specials
+        http-request redirect scheme https if is_specials ! { ssl_fc }
         http-request redirect prefix http://{{ frontend_domain }}%[req.uri] if has_www ! { ssl_fc }
         http-request redirect prefix https://{{ frontend_domain }}%[req.uri] if has_www { ssl_fc }
 


### PR DESCRIPTION
We are not sure about redirecting all traffic to https but it is
probably ok just for the specials static files to use https.

----

Tutor is somehow using the http links for the special files and the browser complains about having http resources... This sort of gets around the problem.  But we might want to find out why Tutor is using http links?