### PR TITLE
Fix reload-vcl script so reload varnish works

### DIFF
--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -16,6 +16,17 @@
     - start varnishncsa
 
 # +++
+# Fix reload-vcl script
+# See https://bugs.launchpad.net/ubuntu/+source/varnish/+bug/1676242
+# +++
+- name: fix reload-vcl script
+  become: yes
+  replace:
+    dest: "/usr/share/varnish/reload-vcl"
+    regexp: 'while getopts a:b:CdFf:g:h:i:l:M:n:P:p:S:s:T:t:u:Vw: flag \$DAEMON_OPTS'
+    replace: 'while getopts a:b:CdFf:g:h:i:j:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS'
+
+# +++
 # Configure
 # +++
 


### PR DESCRIPTION
Right now whenever we reload varnish, we get this error:

```
RUNNING HANDLER [varnish : reload varnish] ***********************************************************************************************************************************
fatal: [local.cnx.org]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to reload service varnish: Job for varnish.service failed because the control process exited with error code. See \"systemctl status varnish.service\" and \"journalctl -xe\" for details.\n"}
```

Looking at `journalctl -xe`:

```
Aug 23 02:39:45 xenial-openstax systemd[1]: Reloading Varnish HTTP accelerator.
-- Subject: Unit varnish.service has begun reloading its configuration
-- Defined-By: systemd
-- Support: http://lists.freedesktop.org/mailman/listinfo/systemd-devel
--
-- Unit varnish.service has begun reloading its configuration
Aug 23 02:39:46 xenial-openstax reload-vcl[13462]: Illegal option -j
Aug 23 02:39:46 xenial-openstax reload-vcl[13462]: Management port disabled. $DAEMON_OPTS must contain '-T hostname:port'
Aug 23 02:39:46 xenial-openstax systemd[1]: varnish.service: Control process exited, code=exited status=1
Aug 23 02:39:46 xenial-openstax systemd[1]: Reload failed for Varnish HTTP accelerator.
```

This is already on the Ubuntu varnish package bug tracker:
https://bugs.launchpad.net/ubuntu/+source/varnish/+bug/1676242