### PR TITLE
Fix static_files nginx config "try_files"

### DIFF
--- a/roles/static_files/templates/etc/nginx/sites-available/static_files
+++ b/roles/static_files/templates/etc/nginx/sites-available/static_files
@@ -13,13 +13,11 @@ server {
         add_header Access-Control-Allow-Origin $cors_header;
     }
 
-    location /files {
+    location ~ ^/files/(.+)$ {
         autoindex off;
-        if ($uri ~ "^/files/(.+)$") {
-            set $fname $1; 
-        }
+        set $fname $1;
         add_header Content-Disposition "attachment; filename=$fname";
         try_files  /files/$1 /files2/$1 $uri  =404;
-    }   
+    }
 
 }


### PR DESCRIPTION
nginx for static_files is returning "404 Not Found" for files in
/var/www/files2.

Move the regular expression to "location" instead.
