### PR TITLE
Update dbmigrator to 1.0.1

### DIFF
--- a/environments/__dev_envs/files/archive-requirements.txt
+++ b/environments/__dev_envs/files/archive-requirements.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/__dev_envs/files/publishing-requirements.txt
+++ b/environments/__dev_envs/files/publishing-requirements.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/des/files/archive-requirements.txt
+++ b/environments/des/files/archive-requirements.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/des/files/publishing-requirements.txt
+++ b/environments/des/files/publishing-requirements.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/prod/files/archive-requirements.txt
+++ b/environments/prod/files/archive-requirements.txt
@@ -4,7 +4,7 @@ cnx-archive==2.5.1
 cnx-db==0.3.0
 cnx-epub==0.10.0
 cnx-query-grammar==0.2.2
-db-migrator==1.0.0
+db-migrator==1.0.1
 funcsigs==1.0.2
 Jinja2==2.7.3
 lxml==3.4.0

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -8,7 +8,7 @@ cnx-publishing==0.6.0
 cnx-query-grammar==0.2.2
 cssselect==0.9.1
 -e git+https://github.com/SimonSapin/cssselect2.git#egg=cssselect2
-db-migrator==1.0.0
+db-migrator==1.0.1
 funcsigs==1.0.2
 Jinja2==2.7.3
 lxml==3.4.0

--- a/environments/staging/files/archive-requirements.txt
+++ b/environments/staging/files/archive-requirements.txt
@@ -4,7 +4,7 @@ cnx-archive==2.5.1
 cnx-db==0.3.0
 cnx-epub==0.10.0
 cnx-query-grammar==0.2.2
-db-migrator==1.0.0
+db-migrator==1.0.1
 funcsigs==1.0.2
 Jinja2==2.7.3
 lxml==3.4.0

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -8,7 +8,7 @@ cnx-publishing==0.6.0
 cnx-query-grammar==0.2.2
 cssselect==0.9.1
 -e git+https://github.com/SimonSapin/cssselect2.git#egg=cssselect2
-db-migrator==1.0.0
+db-migrator==1.0.1
 funcsigs==1.0.2
 Jinja2==2.7.3
 lxml==3.4.0

--- a/environments/vm/files/archive-requirements.txt
+++ b/environments/vm/files/archive-requirements.txt
@@ -4,7 +4,7 @@
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/vm/files/publishing-requirements.txt
+++ b/environments/vm/files/publishing-requirements.txt
@@ -6,7 +6,7 @@
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
-db-migrator==1.0.0
+db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2


### PR DESCRIPTION
This is a dependency update, db-migrator needs psycopg2>=2.7 to be able
to use the `super_user()` context manager.