### PR TITLE
Move db-migrator to top of requirements.txt

### DIFF
--- a/environments/__dev_envs/files/archive-requirements.txt
+++ b/environments/__dev_envs/files/archive-requirements.txt
@@ -1,10 +1,10 @@
+db-migrator==1.0.1
+
 -e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/__dev_envs/files/publishing-requirements.txt
+++ b/environments/__dev_envs/files/publishing-requirements.txt
@@ -1,3 +1,5 @@
+db-migrator==1.0.1
+
 -r archive-requirements.txt
 
 -e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
@@ -5,8 +7,6 @@
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/des/files/archive-requirements.txt
+++ b/environments/des/files/archive-requirements.txt
@@ -1,10 +1,10 @@
+db-migrator==1.0.1
+
 -e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/des/files/publishing-requirements.txt
+++ b/environments/des/files/publishing-requirements.txt
@@ -1,3 +1,5 @@
+db-migrator==1.0.1
+
 -r archive-requirements.txt
 
 -e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
@@ -5,8 +7,6 @@
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/vm/files/archive-requirements.txt
+++ b/environments/vm/files/archive-requirements.txt
@@ -1,10 +1,10 @@
+db-migrator==1.0.1
+
 -e git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
 -e git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=rhaptos.cnxmlutils
 -e git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
 -e git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2

--- a/environments/vm/files/publishing-requirements.txt
+++ b/environments/vm/files/publishing-requirements.txt
@@ -1,3 +1,5 @@
+db-migrator==1.0.1
+
 -r archive-requirements.txt
 
 -e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2
@@ -5,8 +7,6 @@
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
-
-db-migrator==1.0.1
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.2


### PR DESCRIPTION
Pip doesn't have true dependency resolution (see
https://github.com/pypa/pip/issues/988).  For sub-dependencies that are
not specified in requirements.txt , pip uses the the definition of the
first package that specifies the dependency and considers the dependency
satisfied even if there are version conflicts.

In our case, on QA, the installed `psycopg2` is `2.6.2` and
`cnx-archive` requires `psycopg2>=2.5` which is ok, but
`db-migrator-1.0.1` requires `psycopg2>=2.7` which is ignored.

This change moves `db-migrator` to the top of requirements.txt so that
`psycopg2` is updated.