### PR TITLE
Update psycopg2 on prod and staging requirements.txt

### DIFF
--- a/environments/prod/files/archive-requirements.txt
+++ b/environments/prod/files/archive-requirements.txt
@@ -13,7 +13,7 @@ parsimonious==0.6.1
 Paste==1.7.5.1
 PasteDeploy==1.5.2
 PasteScript==1.7.5
-psycopg2==2.5.4
+psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -18,7 +18,7 @@ parsimonious==0.6.1
 Paste==1.7.5.1
 PasteDeploy==1.5.2
 PasteScript==1.7.5
-psycopg2==2.5.4
+psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0

--- a/environments/staging/files/archive-requirements.txt
+++ b/environments/staging/files/archive-requirements.txt
@@ -13,7 +13,7 @@ parsimonious==0.6.1
 Paste==1.7.5.1
 PasteDeploy==1.5.2
 PasteScript==1.7.5
-psycopg2==2.5.4
+psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -18,7 +18,7 @@ parsimonious==0.6.1
 Paste==1.7.5.1
 PasteDeploy==1.5.2
 PasteScript==1.7.5
-psycopg2==2.5.4
+psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0


### PR DESCRIPTION
`db-migrator` requires `psycopg2>=2.7`, the current release for
`psycopg2` is `2.7.3.1` so update prod and staging to use that.

---

The staging and prod version of #371