### PR TITLE
Fix and enhance copy database and datafs playbooks

### DIFF
--- a/copy_database.yml
+++ b/copy_database.yml
@@ -46,7 +46,9 @@
       vars:
         db_owner: "postgres"
     - name: pipe database in
-      shell: "pg_dump -U postgres -h {{ source_db_host }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
+      shell: "set -o pipefail && pg_dump -U postgres -h {{ source_db_host }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
+      args:
+        executable: "/bin/bash"
     - name: migrate database
       debug:
         msg: "Now run the database migration if needed: /var/cnx/venvs/{{ venv_environment|default('publishing') }}/bin/dbmigrator --db-connection-string \"{{ db_connection_string }}\" ... migrate"

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -8,7 +8,7 @@
     - name: "source_db_host"
       prompt: "Where is the database hosted?"
       private: no
-      default: tundra.cnx.rice.edu
+      default: prod09.cnx.org
     - name: "db_name"
       prompt: "What database are we pull from to dump onto this machine?"
       private: no

--- a/copy_datafs.yml
+++ b/copy_datafs.yml
@@ -2,7 +2,6 @@
 
 - name: copy datafs
   hosts: zeo
-  become: yes
   vars_prompt:
     - name: "source_host"
       prompt: "Where is the Data.fs hosted?"
@@ -19,18 +18,18 @@
     destination_filename: "{{ source_filename }}.new"
   tasks:
     - name: temporary filestorage permissions
+      become: yes
       file:
         path: /var/lib/cnx/cnx-buildout/var/filestorage
-        owner: www-data
+        owner: "{{ ansible_user_id }}"
         group: www-data
         mode: 0775
       tags: datafs-perms-temporary
     - name: copy datafs over
-      become: yes
-      become_user: administrator
       shell: "rsync -aP --temp-dir=/tmp/rsync.d --inplace -e ssh {{ source_host }}:{{ source_location }}/{{ source_filename }} /var/lib/cnx/cnx-buildout/var/filestorage/{{ destination_filename }}"
       tags: datafs-sync
     - name: ensure filestorage permissions
+      become: yes
       file:
         path: /var/lib/cnx/cnx-buildout/var/filestorage
         owner: www-data
@@ -38,6 +37,7 @@
         mode: 0755
       tags: datafs-perms-reset
     - name: ensure datafs permissions
+      become: yes
       file:
         path: "/var/lib/cnx/cnx-buildout/var/filestorage/{{ destination_filename }}"
         owner: www-data

--- a/swap_database.yml
+++ b/swap_database.yml
@@ -74,6 +74,7 @@
     - name: rename via pgsql
       shell: |
         psql -v ON_ERROR_STOP=1 --username postgres <<-" EOSQL"
+        DROP DATABASE IF EXISTS {{ dest_db_name }};
         ALTER DATABASE {{ target_db_name }} RENAME TO {{ dest_db_name }};
         ALTER DATABASE {{ origin_db_name }} RENAME TO {{ target_db_name }};
         EOSQL

--- a/swap_database.yml
+++ b/swap_database.yml
@@ -82,6 +82,12 @@
 - name: bootstrap replicant
   hosts: replicant
   tasks:
+    - name: remove old postgresql cluster on replicant
+      become: yes
+      become_user: postgres
+      file:
+        path: "/var/lib/postgresql/{{ postgres_version }}/main/"
+        state: absent
     - name: copy database from master to replicant
       become: yes
       become_user: postgres


### PR DESCRIPTION
Detect pg_dump failure in copy_database.yml

When `pg_dump` failed, because of how the shell works with `|`, the
playbook continued and we had no idea what happened.  We should report
failure when `pg_dump` fails.

By adding `set -o pipefail`, the command will fail when anything before
the `|` or after fails.  Add executable `/bin/bash` as this only works
in bash.

---

Fix copy_datafs permissions problems on destination server 

This is the error we are seeing when copying Data.fs from prod to
staging:

```
rsync: open "/var/lib/cnx/cnx-buildout/var/filestorage/Data.fs.new" failed: Permission denied (13)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1655) [generator=3.1.1]
```

`/var/lib/cnx/cnx-buildout/var/filestorage` was not writeable to the
logged in user.

Change copy_datafs.yml to make the logged in user
`{{ ansible_user_id }}` the owner of
`/var/lib/cnx/cnx-buildout/var/filestorage` temporarily.

Also change copy_datafs.yml to use the logged in user for the rsync
command so it does not try to use root to ssh into the source server.