### PR TITLE
Force git clone / checkout cnx-buildout

### DIFF
--- a/roles/zope_common/tasks/main.yml
+++ b/roles/zope_common/tasks/main.yml
@@ -20,6 +20,7 @@
     repo: "https://github.com/Rhaptos/cnx-buildout.git"
     dest: "/var/lib/cnx/cnx-buildout"
     version: "HEAD"
+    force: yes
   register: git_result
   until: git_result|success
   retries: 5


### PR DESCRIPTION
If there are local changes in cnx-buildout, the "clone source" task fails:

```
TASK [zope_common : clone source] ****************************************************
FAILED - RETRYING: clone source (5 retries left).
ok: [xenial-openstax-test3.local]
FAILED - RETRYING: clone source (4 retries left).
FAILED - RETRYING: clone source (3 retries left).
FAILED - RETRYING: clone source (2 retries left).
FAILED - RETRYING: clone source (1 retries left).
fatal: [xenial-openstax-test2.local]: FAILED! => {"attempts": 5, "before": "85203d6d7512506d40147347cc534f6e35873721", "changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no)."}
```

Force git clone means any modified files in the working directory will be
discarded.