### PR TITLE
Redirect all cnx traffic to SSL

### DIFF
--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -5,6 +5,7 @@
   hosts:
     - frontend
     - legacy_frontend
+    - zope
   # NOOP only to acquire IP address information about hosts.
   tasks: []
 

--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -21,8 +21,9 @@
         acl is_arclishing hdr(host) -i {{ arclishing_domain }}
         acl is_cnxorg hdr(host) -i {{ frontend_domain }}
         acl has_www hdr_beg(host) -i www 
-        acl is_specials path_beg /specials
-        http-request redirect scheme https if is_specials ! { ssl_fc }
+        acl from_zope src 127.0.0.1 {% for host in groups.zope %}{{ hostvars[host].ansible_default_ipv4.address }} {% endfor %}
+
+        http-request redirect scheme https if ! from_zope ! { ssl_fc }
         http-request redirect prefix http://{{ frontend_domain }}%[req.uri] if has_www ! { ssl_fc }
         http-request redirect prefix https://{{ frontend_domain }}%[req.uri] if has_www { ssl_fc }
 


### PR DESCRIPTION
Starting October 2017, Chrome (version 62) will show a "NOT SECURE"
warning when users enter text in a form on an HTTP page and for all HTTP
pages in incognito mode.

Our current PDF generation pipeline does not seem to work with HTTPS
urls (our xslt code is unable to fetch HTTPS url).  So haproxy will not
redirect traffic coming from the zope servers to use SSL.  Everything
else will be redirected.