### PR TITLE
Set rhaptos_print host to frontend domain

### DIFF
--- a/tasks/set_up_rhaptos_print_host.yml
+++ b/tasks/set_up_rhaptos_print_host.yml
@@ -1,0 +1,6 @@
+---
+
+- name: set up rhaptos print host
+  shell: "echo -c \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
+  args:
+    chdir: "/var/lib/cnx/cnx-buildout"

--- a/zope.yml
+++ b/zope.yml
@@ -18,6 +18,8 @@
       run_once: yes
     - include: tasks/set_up_localfs_folders.yml
       run_once: yes
+    - include: tasks/set_up_rhaptos_print_host.yml
+      run_once: yes
   tags:
     - zope
     - create_rhaptos_site


### PR DESCRIPTION
The rhaptos_print tool in plone uses the `_host` attribute for building
zips and pdfs if it exists.  We need to set this to
`http://{{ frontend_domain }}` (not https) so xslt can fetch any urls it
needs when generating the files.