### PR TITLE
Restart cnx apps when code is updated

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -96,6 +96,8 @@
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"
+  notify:
+    - restart archive
 
 # +++
 # Configure
@@ -125,8 +127,6 @@
     - "etc/cnx/archive/vars.sh"
   notify:
     - restart archive
-
-# TODO make logging configuration files for pyramid_sawing
 
 # +++
 # Init service

--- a/roles/authoring/tasks/main.yml
+++ b/roles/authoring/tasks/main.yml
@@ -95,6 +95,8 @@
   pip:
     requirements: "/var/lib/cnx/authoring-requirements.txt"
     virtualenv: "/var/cnx/venvs/authoring"
+  notify:
+    - restart authoring
 
 # +++
 # Configure
@@ -121,6 +123,8 @@
   with_items:
     - {src: "etc/cnx/authoring/app.ini",
        dest: "/etc/cnx/authoring/app.ini"}
+  notify:
+    - restart authoring
 
 # TODO make logging configuration files for pyramid_sawing
 

--- a/roles/publishing_common/handlers/main.yml
+++ b/roles/publishing_common/handlers/main.yml
@@ -1,7 +1,26 @@
 ---
+- name: list supervisor applications
+  become: yes
+  command: supervisorctl avail
+  register: supervisorctl_avail
 
 - name: restart publishing
   become: yes
   supervisorctl:
     name: "publishing:"
     state: restarted
+  when: supervisorctl_avail.stdout.find('publishing:') != -1
+
+- name: restart publishing workers
+  become: yes
+  supervisorctl:
+    name: "publishing_worker:"
+    state: restarted
+  when: supervisorctl_avail.stdout.find('publishing_worker:') != -1
+
+- name: restart channel processing
+  become: yes
+  supervisorctl:
+    name: channel_processing
+    state: restarted
+  when: supervisorctl_avail.stdout.find('channel_processing') != -1

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -100,6 +100,10 @@
   pip:
     requirements: "/var/lib/cnx/publishing-requirements.txt"
     virtualenv: "/var/cnx/venvs/publishing"
+  notify:
+    - restart publishing
+    - restart publishing workers
+    - restart channel processing
 
 # FIXME this won't be necessary once publishing is >=0.7
 - name: check existence of publishing migrations
@@ -147,5 +151,5 @@
     - "etc/cnx/publishing/vars.sh"
   notify:
     - restart publishing
-
-# TODO make logging configuration files for pyramid_sawing
+    - restart publishing workers
+    - restart channel processing

--- a/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
+++ b/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
@@ -6,5 +6,5 @@ user=www-data
 
 {% endfor %}
 
-[group:publishing]
+[group:publishing_worker]
 programs={% for i in range(0, hostvars[inventory_hostname].publishing_worker_count|default(1), 1) %}publishing_celery_worker{{ i }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
- Change celery supervisor group to publishing_worker

  The publishing celery workers supervisor group was "publishing", which
  is shared with the publishing pyramid application in another supervisor
  config file.  This does not seem to work when we do
  `supervisor restart publishing:`.  It restarts the publishing celery
  workers but not the publishing pyramid application.
  
  So we are giving the publishing celery workers a new group so we can
  continue to restart using groups.

- Restart cnx apps when code is updated

  Right now it seems our applications are only restarted when there is
  configuration change.  We need to restart the apps when our code change
  as well.
  
  For archive and authoring, it is straightforward, we just need to detect
  a config change or code change to restart the apps.
  
  For publishing, channel processing and publishing workers, we have to
  restart these processes the first time publishing is installed on the
  servers in order to detect whether code has been updated.  Since
  publishing_common is a prerequisite of all of the publishing roles, we
  don't know in advance which one is installed on the server.  So we are
  going to try to restart all of them if they are configured with
  supervisor.
