### PR TITLE
Forward cnx app logs to rsyslog (and to graylog)

### DIFF
--- a/roles/archive/meta/main.yml
+++ b/roles/archive/meta/main.yml
@@ -5,3 +5,4 @@ dependencies:
   - python2
   - memcached
   - supervisord
+  - rsyslog

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -160,3 +160,19 @@
     owner: root
     group: root
     mode: 0750
+
+# +++
+# Rsyslog Configuration
+# +++
+
+- name: connect archive log to rsyslog
+  become: yes
+  template:
+    src: "etc/rsyslog.d/10-archive.conf"
+    dest: "/etc/rsyslog.d/10-archive.conf"
+    mode: 0644
+  notify:
+    - set up supervisor logs
+    - restart rsyslog
+  tags:
+    - archive-rsyslog

--- a/roles/archive/templates/etc/rsyslog.d/10-archive.conf
+++ b/roles/archive/templates/etc/rsyslog.d/10-archive.conf
@@ -1,0 +1,8 @@
+module(load="imfile")
+
+input(type="imfile"
+      File="/var/log/supervisor/archive*.log"
+      Tag="cnxarchive"
+      Severity="info")
+
+if $syslogtag == "cnxarchive" and ({% for host in groups.lead_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~

--- a/roles/authoring/meta/main.yml
+++ b/roles/authoring/meta/main.yml
@@ -5,3 +5,4 @@ dependencies:
   - python2
   - memcached
   - supervisord
+  - rsyslog

--- a/roles/authoring/tasks/main.yml
+++ b/roles/authoring/tasks/main.yml
@@ -148,3 +148,19 @@
     mode: 0644
   notify:
     - reload supervisord
+
+# +++
+# Rsyslog Configuration
+# +++
+
+- name: connect authoring log to rsyslog
+  become: yes
+  template:
+    src: "etc/rsyslog.d/10-authoring.conf"
+    dest: "/etc/rsyslog.d/10-authoring.conf"
+    mode: 0644
+  notify:
+    - set up supervisor logs
+    - restart rsyslog
+  tags:
+    - authoring-rsyslog

--- a/roles/authoring/templates/etc/rsyslog.d/10-authoring.conf
+++ b/roles/authoring/templates/etc/rsyslog.d/10-authoring.conf
@@ -1,0 +1,6 @@
+module(load="imfile")
+
+input(type="imfile"
+      File="/var/log/supervisor/authoring*.log"
+      Tag="cnxauthoring"
+      Severity="info")

--- a/roles/channel_processing/meta/main.yml
+++ b/roles/channel_processing/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - publishing_common
+  - rsyslog

--- a/roles/channel_processing/tasks/main.yml
+++ b/roles/channel_processing/tasks/main.yml
@@ -13,3 +13,19 @@
     mode: 0644
   notify:
     - reload supervisord
+
+# +++
+# Rsyslog Configuration
+# +++
+
+- name: connect channel processing log to rsyslog
+  become: yes
+  template:
+    src: "etc/rsyslog.d/10-channel-processing.conf"
+    dest: "/etc/rsyslog.d/10-channel-processing.conf"
+    mode: 0644
+  notify:
+    - set up supervisor logs
+    - restart rsyslog
+  tags:
+    - channel-processing-rsyslog

--- a/roles/channel_processing/templates/etc/rsyslog.d/10-channel-processing.conf
+++ b/roles/channel_processing/templates/etc/rsyslog.d/10-channel-processing.conf
@@ -1,0 +1,6 @@
+module(load="imfile")
+
+input(type="imfile"
+      File="/var/log/supervisor/channel_processing*.log"
+      Tag="channel_processing"
+      Severity="info")

--- a/roles/publishing/meta/main.yml
+++ b/roles/publishing/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - publishing_common
+  - rsyslog

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -41,3 +41,19 @@
   notify:
     - reload supervisord
 # /XXX
+
+# +++
+# Rsyslog Configuration
+# +++
+
+- name: connect publishing log to rsyslog
+  become: yes
+  template:
+    src: "etc/rsyslog.d/10-publishing.conf"
+    dest: "/etc/rsyslog.d/10-publishing.conf"
+    mode: 0644
+  notify:
+    - set up supervisor logs
+    - restart rsyslog
+  tags:
+    - publishing-rsyslog

--- a/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
+++ b/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
@@ -1,0 +1,8 @@
+module(load="imfile")
+
+input(type="imfile"
+      File="/var/log/supervisor/publishing[0-9]*.log"
+      Tag="cnxpublishing"
+      Severity="info")
+
+if $syslogtag == "cnxpublishing" and ({% for host in groups.lead_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~

--- a/roles/publishing_worker/meta/main.yml
+++ b/roles/publishing_worker/meta/main.yml
@@ -2,3 +2,4 @@
 
 dependencies:
   - publishing_common
+  - rsyslog

--- a/roles/publishing_worker/tasks/main.yml
+++ b/roles/publishing_worker/tasks/main.yml
@@ -13,3 +13,19 @@
     mode: 0644
   notify:
     - reload supervisord
+
+# +++
+# Rsyslog Configuration
+# +++
+
+- name: connect publishing worker log to rsyslog
+  become: yes
+  template:
+    src: "etc/rsyslog.d/10-publishing-worker.conf"
+    dest: "/etc/rsyslog.d/10-publishing-worker.conf"
+    mode: 0644
+  notify:
+    - set up supervisor logs
+    - restart rsyslog
+  tags:
+    - publishing-worker-rsyslog

--- a/roles/publishing_worker/templates/etc/rsyslog.d/10-publishing-worker.conf
+++ b/roles/publishing_worker/templates/etc/rsyslog.d/10-publishing-worker.conf
@@ -1,0 +1,6 @@
+module(load="imfile")
+
+input(type="imfile"
+      File="/var/log/supervisor/publishing_celery_worker*.log"
+      Tag="cnxpublishing_worker"
+      Severity="info")

--- a/roles/supervisord/handlers/main.yml
+++ b/roles/supervisord/handlers/main.yml
@@ -6,6 +6,8 @@
     name: supervisor
     state: restarted
   register: restart_supervisor_handler
+  notify:
+    - set up supervisor logs
 
 - name: reload supervisord
   when: restart_supervisor_handler is undefined
@@ -13,3 +15,9 @@
   service:
     name: supervisor
     state: reloaded
+  notify:
+    - set up supervisor logs
+
+- name: set up supervisor logs
+  become: yes
+  shell: "chmod 644 /var/log/supervisor/*"


### PR DESCRIPTION
This will give people access to the application logs without them having
to ssh into the server.

Use `chmod` to set the files to readable by everyone.  The supervisor
logs are currently owned by root and only readable and writable by root.
There doesn't seem to be any way to configure this with the current
supervisor version.

Add rsyslog configuration files to read supervisor log files.