### PR TITLE
remove config from webview for concept coach - EOL

### DIFF
--- a/environments/des/group_vars/all/vars.yml
+++ b/environments/des/group_vars/all/vars.yml
@@ -44,26 +44,6 @@ nfs_server_for_specials: des00.cnx.org
 
 webview_version: v0.22.1rc4
 
-concept_coach_webview_settings:
-  '08df2bee-3db4-4243-bd76-ee032da173e8': ['self-check-questions','review-questions','critical-thinking','problems']
-  'CN8r7j20': ['self-check-questions','review-questions','critical-thinking','problems']
-  '27275f49-f212-4506-b3b1-a4d5e3598b99': ['conceptual-questions','problems-exercises']
-  'JydfSfIS': ['conceptual-questions','problems-exercises']
-  '4f86c023-a135-412a-9d96-dcbd1ca61e7d': ['section-quiz','short-answer','further-research']
-  'T4bAI6E1': ['section-quiz','short-answer','further-research']
-  'd393e255-30b3-4ba7-bc78-2fd7a4324ec8': ['section-quiz','short-answer','further-research']
-  '05PiVTCz': ['section-quiz','short-answer','further-research']
-  '947a1417-5fd5-4b3c-ac8f-bd9d1aedf2d2': ['self-check-questions','review-questions','critical-thinking','problems']
-  'lHoUF1_V': ['self-check-questions','review-questions','critical-thinking','problems']
-  'bf96bfc5-e723-46c2-9fa2-5a4c9294fa26': ['art-exercise','multiple-choice','free-response']
-  'v5a_xecj': ['art-exercise','multiple-choice','free-response']
-  'd2fbadca-e4f3-4432-a074-2438c216b62a': ['self-check-questions','review-questions','critical-thinking','problems']
-  '0vutyuTz': ['self-check-questions','review-questions','critical-thinking','problems']
-  '3402dc53-113d-45f3-954e-8d2ad1e73659': ['art-exercise','multiple-choice','free-response']
-  'NALcUxE9': ['art-exercise','multiple-choice','free-response']
-  '99e127f8-f722-4907-a6b3-2d62fca135d6': ['art-exercise','multiple-choice','free-response','interactive-exercise']
-  'meEn-Pci': ['art-exercise','multiple-choice','free-response']
-
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"
 
 graylog_server: "{{ default_graylog_server }}"

--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -55,24 +55,4 @@ nfs_server_for_varnish_logs: dev00.cnx.org
 
 webview_version: master
 
-concept_coach_webview_settings:
-  '08df2bee-3db4-4243-bd76-ee032da173e8': ['self-check-questions','review-questions','critical-thinking','problems']
-  'CN8r7j20': ['self-check-questions','review-questions','critical-thinking','problems']
-  '27275f49-f212-4506-b3b1-a4d5e3598b99': ['conceptual-questions','problems-exercises']
-  'JydfSfIS': ['conceptual-questions','problems-exercises']
-  '4f86c023-a135-412a-9d96-dcbd1ca61e7d': ['section-quiz','short-answer','further-research']
-  'T4bAI6E1': ['section-quiz','short-answer','further-research']
-  'd393e255-30b3-4ba7-bc78-2fd7a4324ec8': ['section-quiz','short-answer','further-research']
-  '05PiVTCz': ['section-quiz','short-answer','further-research']
-  '947a1417-5fd5-4b3c-ac8f-bd9d1aedf2d2': ['self-check-questions','review-questions','critical-thinking','problems']
-  'lHoUF1_V': ['self-check-questions','review-questions','critical-thinking','problems']
-  'bf96bfc5-e723-46c2-9fa2-5a4c9294fa26': ['art-exercise','multiple-choice','free-response']
-  'v5a_xecj': ['art-exercise','multiple-choice','free-response']
-  'd2fbadca-e4f3-4432-a074-2438c216b62a': ['self-check-questions','review-questions','critical-thinking','problems']
-  '0vutyuTz': ['self-check-questions','review-questions','critical-thinking','problems']
-  '3402dc53-113d-45f3-954e-8d2ad1e73659': ['art-exercise','multiple-choice','free-response']
-  'NALcUxE9': ['art-exercise','multiple-choice','free-response']
-  '99e127f8-f722-4907-a6b3-2d62fca135d6': ['art-exercise','multiple-choice','free-response','interactive-exercise']
-  'meEn-Pci': ['art-exercise','multiple-choice','free-response']
-
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -74,24 +74,4 @@ google_site_verification_filename: "{{ vault_google_site_verification_filename }
 
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
-concept_coach_webview_settings:
-  '08df2bee-3db4-4243-bd76-ee032da173e8': ['self-check-questions','review-questions','critical-thinking','problems']
-  'CN8r7j20': ['self-check-questions','review-questions','critical-thinking','problems']
-  '27275f49-f212-4506-b3b1-a4d5e3598b99': ['conceptual-questions','problems-exercises']
-  'JydfSfIS': ['conceptual-questions','problems-exercises']
-  '4f86c023-a135-412a-9d96-dcbd1ca61e7d': ['section-quiz','short-answer','further-research']
-  'T4bAI6E1': ['section-quiz','short-answer','further-research']
-  'd393e255-30b3-4ba7-bc78-2fd7a4324ec8': ['section-quiz','short-answer','further-research']
-  '05PiVTCz': ['section-quiz','short-answer','further-research']
-  '947a1417-5fd5-4b3c-ac8f-bd9d1aedf2d2': ['self-check-questions','review-questions','critical-thinking','problems']
-  'lHoUF1_V': ['self-check-questions','review-questions','critical-thinking','problems']
-  'bf96bfc5-e723-46c2-9fa2-5a4c9294fa26': ['art-exercise','multiple-choice','free-response']
-  'v5a_xecj': ['art-exercise','multiple-choice','free-response']
-  'd2fbadca-e4f3-4432-a074-2438c216b62a': ['self-check-questions','review-questions','critical-thinking','problems']
-  '0vutyuTz': ['self-check-questions','review-questions','critical-thinking','problems']
-  '3402dc53-113d-45f3-954e-8d2ad1e73659': ['art-exercise','multiple-choice','free-response']
-  'NALcUxE9': ['art-exercise','multiple-choice','free-response']
-  '99e127f8-f722-4907-a6b3-2d62fca135d6': ['art-exercise','multiple-choice','free-response','interactive-exercise']
-  'meEn-Pci': ['art-exercise','multiple-choice','free-response']
-
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -55,24 +55,4 @@ nfs_server_for_specials: "{{ _host_prefix }}.cnx.org"
 
 webview_version: master
 
-concept_coach_webview_settings:
-  '08df2bee-3db4-4243-bd76-ee032da173e8': ['self-check-questions','review-questions','critical-thinking','problems']
-  'CN8r7j20': ['self-check-questions','review-questions','critical-thinking','problems']
-  '27275f49-f212-4506-b3b1-a4d5e3598b99': ['conceptual-questions','problems-exercises']
-  'JydfSfIS': ['conceptual-questions','problems-exercises']
-  '4f86c023-a135-412a-9d96-dcbd1ca61e7d': ['section-quiz','short-answer','further-research']
-  'T4bAI6E1': ['section-quiz','short-answer','further-research']
-  'd393e255-30b3-4ba7-bc78-2fd7a4324ec8': ['section-quiz','short-answer','further-research']
-  '05PiVTCz': ['section-quiz','short-answer','further-research']
-  '947a1417-5fd5-4b3c-ac8f-bd9d1aedf2d2': ['self-check-questions','review-questions','critical-thinking','problems']
-  'lHoUF1_V': ['self-check-questions','review-questions','critical-thinking','problems']
-  'bf96bfc5-e723-46c2-9fa2-5a4c9294fa26': ['art-exercise','multiple-choice','free-response']
-  'v5a_xecj': ['art-exercise','multiple-choice','free-response']
-  'd2fbadca-e4f3-4432-a074-2438c216b62a': ['self-check-questions','review-questions','critical-thinking','problems']
-  '0vutyuTz': ['self-check-questions','review-questions','critical-thinking','problems']
-  '3402dc53-113d-45f3-954e-8d2ad1e73659': ['art-exercise','multiple-choice','free-response']
-  'NALcUxE9': ['art-exercise','multiple-choice','free-response']
-  '99e127f8-f722-4907-a6b3-2d62fca135d6': ['art-exercise','multiple-choice','free-response','interactive-exercise']
-  'meEn-Pci': ['art-exercise','multiple-choice','free-response']
-
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -73,24 +73,4 @@ webview_version: v0.23.1
 
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 
-concept_coach_webview_settings:
-  '08df2bee-3db4-4243-bd76-ee032da173e8': ['self-check-questions','review-questions','critical-thinking','problems']
-  'CN8r7j20': ['self-check-questions','review-questions','critical-thinking','problems']
-  '27275f49-f212-4506-b3b1-a4d5e3598b99': ['conceptual-questions','problems-exercises']
-  'JydfSfIS': ['conceptual-questions','problems-exercises']
-  '4f86c023-a135-412a-9d96-dcbd1ca61e7d': ['section-quiz','short-answer','further-research']
-  'T4bAI6E1': ['section-quiz','short-answer','further-research']
-  'd393e255-30b3-4ba7-bc78-2fd7a4324ec8': ['section-quiz','short-answer','further-research']
-  '05PiVTCz': ['section-quiz','short-answer','further-research']
-  '947a1417-5fd5-4b3c-ac8f-bd9d1aedf2d2': ['self-check-questions','review-questions','critical-thinking','problems']
-  'lHoUF1_V': ['self-check-questions','review-questions','critical-thinking','problems']
-  'bf96bfc5-e723-46c2-9fa2-5a4c9294fa26': ['art-exercise','multiple-choice','free-response']
-  'v5a_xecj': ['art-exercise','multiple-choice','free-response']
-  'd2fbadca-e4f3-4432-a074-2438c216b62a': ['self-check-questions','review-questions','critical-thinking','problems']
-  '0vutyuTz': ['self-check-questions','review-questions','critical-thinking','problems']
-  '3402dc53-113d-45f3-954e-8d2ad1e73659': ['art-exercise','multiple-choice','free-response']
-  'NALcUxE9': ['art-exercise','multiple-choice','free-response']
-  '99e127f8-f722-4907-a6b3-2d62fca135d6': ['art-exercise','multiple-choice','free-response','interactive-exercise']
-  'meEn-Pci': ['art-exercise','multiple-choice','free-response']
-
 princexml_deb_url: "http://www.princexml.com/download/prince_11-1_ubuntu16.04_amd64.deb"

--- a/roles/webview/templates/var/www/webview/scripts/settings.js
+++ b/roles/webview/templates/var/www/webview/scripts/settings.js
@@ -55,13 +55,7 @@
 
       defaultLicense: {
         code: 'by'
-      },
-
-      conceptCoach: {
-        uuids: {{ concept_coach_webview_settings|default({})|to_json }},
-        url: 'https://{{ tutor_domain|default("tutor-qa.openstax.org") }}'
       }
-
     };
 
   });


### PR DESCRIPTION
Concept Coach is being shut off today. This is the minimal config change to cause webview to not generate the 'Jump to Concept Coach' button, and attempt to replace in-line exercises with the CC functionality.