### PR TITLE
Comment out the self signed cert in lead_frontend.yml

### DIFF
--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -8,22 +8,22 @@
   # NOOP only to acquire IP address information about hosts.
   tasks: []
 
-- name: generate a self-signed certificate
-  hosts: 127.0.0.1
-  connection: local
-  vars:
-    cert_password: "password"
-    cert_domain: "*.{{ frontend_domain }}"
-    cert_dir: "{{ inventory_dir }}/secrets/certs"
-    cert_pem_filepath: "{{ cert_dir }}/{{ frontend_domain }}.pem"
-  tasks:
-    - file:
-        path: "{{ cert_dir }}"
-        state: directory
-    - stat: path="{{ cert_pem_filepath }}"
-      register: pem_file
-    - include: tasks/create_self_signed_cert.yml
-      when: not pem_file.stat.exists
+#- name: generate a self-signed certificate
+#  hosts: 127.0.0.1
+#  connection: local
+#  vars:
+#    cert_password: "password"
+#    cert_domain: "*.{{ frontend_domain }}"
+#    cert_dir: "{{ inventory_dir }}/secrets/certs"
+#    cert_pem_filepath: "{{ cert_dir }}/{{ frontend_domain }}.pem"
+#  tasks:
+#    - file:
+#        path: "{{ cert_dir }}"
+#        state: directory
+#    - stat: path="{{ cert_pem_filepath }}"
+#      register: pem_file
+#    - include: tasks/create_self_signed_cert.yml
+#      when: not pem_file.stat.exists
 
 - name: setup initial request frontend services
   hosts:


### PR DESCRIPTION
Localhost `inventory_dir` is not defined causing this error when running
playbook `lead_frontend.yml`:

```
TASK [file] ******************************************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"failed": true, "msg": "The task includes an option with an undefined variable. The error was: {{ inventory_dir }}/secrets/certs: 'inventory_d
ir' is undefined\n\nThe error appears to have been in '/home/karen/src/cnx-deploy/lead_frontend.yml': line 20, column 7, but may\nbe elsewhere in the file depending on the ex
act syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n    - file:\n      ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: {{ inventory_dir }}/secrets/certs: 'inventory_dir' is undefined"}
```

See bug report for ansible v2.4.0:
https://github.com/ansible/ansible/issues/31087

---

I would like to add this back later so we can kind of use https locally.  But I think it's best to wait until ansible to fixed.