### PR TITLE
Change self signed cert tasks to local_action

### DIFF
--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -9,22 +9,27 @@
   # NOOP only to acquire IP address information about hosts.
   tasks: []
 
-#- name: generate a self-signed certificate
-#  hosts: 127.0.0.1
-#  connection: local
-#  vars:
-#    cert_password: "password"
-#    cert_domain: "*.{{ frontend_domain }}"
-#    cert_dir: "{{ inventory_dir }}/secrets/certs"
-#    cert_pem_filepath: "{{ cert_dir }}/{{ frontend_domain }}.pem"
-#  tasks:
-#    - file:
-#        path: "{{ cert_dir }}"
-#        state: directory
-#    - stat: path="{{ cert_pem_filepath }}"
-#      register: pem_file
-#    - include: tasks/create_self_signed_cert.yml
-#      when: not pem_file.stat.exists
+- name: generate a self-signed certificate
+  hosts:
+    - lead_frontend
+  vars:
+    cert_password: "password"
+    cert_domain: "*.{{ frontend_domain }}"
+    cert_dir: "{{ inventory_dir }}/secrets/certs"
+    cert_pem_filepath: "{{ cert_dir }}/{{ frontend_domain }}.pem"
+  tasks:
+    - local_action:
+        module: file
+        path: "{{ cert_dir }}"
+        state: directory
+    - local_action:
+        module: stat
+        path: "{{ cert_pem_filepath }}"
+      register: pem_file
+    - include: tasks/create_self_signed_cert.yml
+      delegate_to: 127.0.0.1
+      when: not pem_file.stat.exists
+  run_once: yes
 
 - name: setup initial request frontend services
   hosts:


### PR DESCRIPTION
This gets around the localhost `inventory_dir` not defined error when
running `lead_frontend.yml`:

```
TASK [file] ******************************************************************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"failed": true, "msg": "The task includes an option with an undefined variable. The error was: {{ inventory_dir }}/secrets/certs: 'inventory_d
ir' is undefined\n\nThe error appears to have been in '/home/karen/src/cnx-deploy/lead_frontend.yml': line 20, column 7, but may\nbe elsewhere in the file depending on the ex
act syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n    - file:\n      ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: {{ inventory_dir }}/secrets/certs: 'inventory_dir' is undefined"}
```

See bug report for ansible v2.4.0:
https://github.com/ansible/ansible/issues/31087