### PR TITLE
Add executable to shell command in tasks

### DIFF
--- a/roles/zeopack/tasks/main.yml
+++ b/roles/zeopack/tasks/main.yml
@@ -2,9 +2,9 @@
 
 - name: create zeopack cronjob
   become: yes
-  become_user: "www-data"
   cron:
     name: zeopack
     state: present
     special_time: weekly
     job: "/var/lib/cnx/cnx-buildout/bin/zeopack"
+    user: "www-data"

--- a/roles/zope_common/tasks/install_cnx_buildout.yml
+++ b/roles/zope_common/tasks/install_cnx_buildout.yml
@@ -82,6 +82,7 @@
   shell: "/var/cnx/venvs/cnx-buildout/bin/python bootstrap.py"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
+    executable: "/bin/sh"
   tags: buildout-bootstrap
 
 - name: install simplejson 1.9.2


### PR DESCRIPTION
- Add executable to shell command in tasks

  Ansible v2.4.0 uses the `become_user` default shell or `$SHELL`
  environment variable which is a problem if the `become_user` has
  `/usr/sbin/nologin` or `/bin/false` as their default shell.  (The
  default shell can be found in `/etc/passwd`)
  
  The error when running the main playbook:
  
  ```
  TASK [zope_common : run bootstrap]
  *******************************************************************************************************************************************
  fatal: [staging04.cnx.org]: FAILED! => {"changed": true, "cmd": "/var/cnx/venvs/cnx-buildout/bin/python bootstrap.py", "delta": "0:00:00.013276", "end": "2017-10-03 08:35:30.042500", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2017-10-03 08:35:30.029224", "stderr": "", "stderr_lines": [], "stdout": "This account is currently not available.", "stdout_lines": ["This account is currently not available."]}
  fatal: [staging05.cnx.org]: FAILED! => {"changed": true, "cmd": "/var/cnx/venvs/cnx-buildout/bin/python bootstrap.py", "delta": "0:00:00.007503", "end": "2017-10-03 08:35:30.049117", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2017-10-03 08:35:30.041614", "stderr": "", "stderr_lines": [], "stdout": "This account is currently not available.", "stdout_lines": ["This account is currently not available."]}
  fatal: [staging06.cnx.org]: FAILED! => {"changed": true, "cmd": "/var/cnx/venvs/cnx-buildout/bin/python bootstrap.py", "delta": "0:00:00.020954", "end": "2017-10-03 08:35:30.074102", "failed": true, "msg": "non-zero return code", "rc": 1, "start": "2017-10-03 08:35:30.053148", "stderr": "", "stderr_lines": [], "stdout": "This account is currently not available.", "stdout_lines": ["This account is currently not available."]}
  ```
  
  Also see https://github.com/ansible/ansible/issues/26741
  
  Change zope_common run bootstrap task to include `executable` in the
  shell command with `www-data` as the user.

- Set zeopack cron user to www-data instead of using become_user

  The cron task fails with no error message:
  
  ```
  TASK [zeopack : create zeopack cronjob] **************************************************************************************************************************************
  fatal: [local.cnx.org]: FAILED! => {"changed": false, "failed": true, "msg": ""}
  ```
  
  The cron task fails when doing `self.module.run_command` possibly broken
  because ansible v2.4.0 started using the user's default shell instead of
  `/bin/sh`.  Since the cron module takes a "user" argument, we will use that
  instead.

