### PR TITLE
Update push_data to stop and start all publishing services

### DIFF
--- a/push_data.yml
+++ b/push_data.yml
@@ -39,10 +39,16 @@
 
 - name: stop publishing
   hosts: publishing
+  become: yes
   tasks:
-    - become: yes
-      supervisorctl:
+    - supervisorctl:
         name: "publishing:"
+        state: stopped
+    - supervisorctl:
+        name: "publishing_worker:"
+        state: stopped
+    - supervisorctl:
+        name: "channel_processing"
         state: stopped
 
 - name: stop zclients
@@ -102,10 +108,16 @@
 
 - name: start publishing
   hosts: publishing
+  become: yes
   tasks:
-    - become: yes
-      supervisorctl:
+    - supervisorctl:
         name: "publishing:"
+        state: started
+    - supervisorctl:
+        name: "publishing_worker:"
+        state: started
+    - supervisorctl:
+        name: "channel_processing"
         state: started
 
 - name: start zclients


### PR DESCRIPTION
Channel processing and publishing celery workers are connected to the
database so they need to be stopped before dropping the database.

Depends on #384.