### PR TITLE
be explicit about celery worker queues

### DIFF
--- a/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
+++ b/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
@@ -1,7 +1,7 @@
 {% for i in range(0, hostvars[inventory_hostname].publishing_worker_count|default(1), 1) %}
 [program:publishing_celery_worker{{ i }}]
 environment=PYRAMID_INI="/etc/cnx/publishing/app.ini"
-command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing
+command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing -Q default -Q deferred
 user=www-data
 
 {% endfor %}


### PR DESCRIPTION
I ran into this again while working on baking locally. My locally launched workers would connect, then shutdown. If I add the list of queues, they work properly. I presume there's an underlying celery bug.
We don't want to hit this in production.