### PR TITLE
Upgrade pyramid_sawing to 1.1.3

### DIFF
--- a/environments/__dev_envs/files/archive-requirements.txt
+++ b/environments/__dev_envs/files/archive-requirements.txt
@@ -7,5 +7,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/__dev_envs/files/authoring-requirements.txt
+++ b/environments/__dev_envs/files/authoring-requirements.txt
@@ -4,5 +4,5 @@
 -e git+https://github.com/Connexions/cnx-authoring.git#egg=cnx-authoring
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/__dev_envs/files/publishing-requirements.txt
+++ b/environments/__dev_envs/files/publishing-requirements.txt
@@ -9,5 +9,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/des/files/archive-requirements.txt
+++ b/environments/des/files/archive-requirements.txt
@@ -7,5 +7,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/des/files/authoring-requirements.txt
+++ b/environments/des/files/authoring-requirements.txt
@@ -4,5 +4,5 @@
 -e git+https://github.com/Connexions/cnx-authoring.git#egg=cnx-authoring
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/des/files/publishing-requirements.txt
+++ b/environments/des/files/publishing-requirements.txt
@@ -9,5 +9,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/prod/files/archive-requirements.txt
+++ b/environments/prod/files/archive-requirements.txt
@@ -17,7 +17,7 @@ psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -22,7 +22,7 @@ psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/staging/files/archive-requirements.txt
+++ b/environments/staging/files/archive-requirements.txt
@@ -17,7 +17,7 @@ psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -22,7 +22,7 @@ psycopg2==2.7.3.1
 pyramid==1.6a2
 pyramid-jinja2==2.6.2
 pyramid-multiauth==0.8.0
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 pyramid-translogger==0.1
 python-memcached==1.53
 pytz==2017.2

--- a/environments/vm/files/archive-requirements.txt
+++ b/environments/vm/files/archive-requirements.txt
@@ -7,5 +7,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/vm/files/authoring-requirements.txt
+++ b/environments/vm/files/authoring-requirements.txt
@@ -4,5 +4,5 @@
 -e git+https://github.com/Connexions/cnx-authoring.git#egg=cnx-authoring
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2

--- a/environments/vm/files/publishing-requirements.txt
+++ b/environments/vm/files/publishing-requirements.txt
@@ -9,5 +9,5 @@ db-migrator==1.0.1
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
 
 # Deployment specific dependencies
-pyramid_sawing==1.1.2
+pyramid_sawing==1.1.3
 waitress>=1.0,<2


### PR DESCRIPTION
- Adjust the transit logging tween to set and return the response
  attribute of the request object.

This should fix the problem of getting "200 OK" for all requests in our
archive and publishing logs.