### PR TITLE
Create version.txt to list package versions on servers

### DIFF
--- a/archive.yml
+++ b/archive.yml
@@ -18,3 +18,6 @@
   tags:
     - archive
     - be
+
+- when: not_standalone is undefined
+  include: update_versions.yml

--- a/frontend.yml
+++ b/frontend.yml
@@ -29,3 +29,6 @@
 #    - webview
 #    - static_files
 #    - fe
+
+- when: not_standalone is undefined
+  include: update_versions.yml

--- a/main.yml
+++ b/main.yml
@@ -27,13 +27,13 @@
 # Applications
 # +++
 
-- import_playbook: archive.yml
-- import_playbook: publishing.yml
+- import_playbook: archive.yml not_standalone=yes
+- import_playbook: publishing.yml not_standalone=yes
 - import_playbook: channel_processing.yml
 - import_playbook: publishing_worker.yml
 - import_playbook: authoring.yml
 
-- import_playbook: zope.yml
+- import_playbook: zope.yml not_standalone=yes
   tags:
     - zope
     - zeo
@@ -49,7 +49,7 @@
     - legacy_fe
     - fe
 
-- import_playbook: frontend.yml
+- import_playbook: frontend.yml not_standalone=yes
   tags:
     - nginx
     - varnish
@@ -66,6 +66,8 @@
   tags:
     - iptables
     - firewall
+
+- include: update_versions.yml
 
 - name: "notify #cnx-stream of the deployment (end)"
   hosts: all

--- a/publishing.yml
+++ b/publishing.yml
@@ -18,3 +18,6 @@
   tags:
     - publishing
     - be
+
+- when: not_standalone is undefined
+  include: update_versions.yml

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -107,6 +107,7 @@ backend {{ backend_name }} {
 acl purge {
     "localhost";
     "127.0.0.1";
+    "{{ frontend_domain }}";
     # TODO Include IP addresses of other serving hosts.
 }
 

--- a/roles/webview/tasks/webview.yml
+++ b/roles/webview/tasks/webview.yml
@@ -29,8 +29,6 @@
         dest: "{{ _install_location }}"
         owner: www-data
         group: www-data
-    - name: write version.txt
-      command: "echo '{{ webview_version }}' > {{ _install_location }}/version.txt"
     - name: link to /var/www/webview
       become: yes
       file:

--- a/update_versions.yml
+++ b/update_versions.yml
@@ -1,0 +1,116 @@
+---
+
+- name: get webview version
+  hosts: frontend
+  tasks:
+    - shell: cat /var/www/webview/rev.txt
+      register: webview_version
+
+- name: get archive versions
+  hosts: frontend
+  tasks:
+    - shell: /var/cnx/venvs/archive/bin/pip freeze | grep 'cnx-archive'
+      register: archive_version
+      delegate_to: "{{ item }}"
+      with_items:
+        - "{{ groups.archive|first }}"
+    - shell: /var/cnx/venvs/archive/bin/pip freeze
+      register: archive_full_versions
+      delegate_to: "{{ item }}"
+      with_items:
+        - "{{ groups.archive|first }}"
+
+- name: get publishing versions
+  hosts: frontend
+  tasks:
+    - shell: /var/cnx/venvs/publishing/bin/pip freeze | grep 'cnx-publishing'
+      register: publishing_version
+      delegate_to: "{{ item }}"
+      with_items:
+        - "{{ groups.publishing|first }}"
+    - shell: /var/cnx/venvs/publishing/bin/pip freeze
+      register: publishing_full_versions
+      delegate_to: "{{ item }}"
+      with_items:
+        - "{{ groups.publishing|first }}"
+
+- name: get legacy versions
+  hosts: frontend
+  tasks:
+    - shell: echo 'import pip; pip.main(["freeze"])' | /var/lib/cnx/cnx-buildout/bin/instance debug
+      register: legacy_full_versions
+      delegate_to: "{{ item }}"
+      with_items:
+        - "{{ groups.zope|first }}"
+
+- name: get cnx-deploy version
+  hosts: frontend
+  tasks:
+    - shell: git describe --tags
+      register: cnx_deploy_version
+      delegate_to: 127.0.0.1
+
+- name: update version.txt
+  hosts: frontend
+  become: yes
+  become_user: www-data
+  tasks:
+    - shell:
+        cmd: |
+          date +'{"date": "%Y-%m-%d %H:%M:%S %Z",'>/var/www/webview/version.txt
+          cat >>/var/www/webview/version.txt <<EOF
+           "webview": "{{ webview_version.stdout }}",
+           "cnx-archive": "{{ archive_version.results.0.stdout|regex_replace('^[^@]*@([^#]*).*$', '\1')|regex_replace('^[^=]*==') }}",
+           "cnx-publishing": "{{ publishing_version.results.0.stdout|regex_replace('^[^@]*@([^#]*).*$', '\1')|regex_replace('^[^=]*==') }}",
+           "cnx-deploy": "{{ cnx_deploy_version.stdout }}"
+          }
+          EOF
+      args:
+        executable: /bin/sh
+    - name: purge cached version.txt
+      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/version.txt'"
+
+- name: update python-version.txt
+  hosts: frontend
+  become: yes
+  become_user: www-data
+  tasks:
+    - shell:
+        cmd: |
+          date +'# %Y-%m-%d %H:%M:%S %Z'>/var/www/webview/python-version.txt
+          cat >>/var/www/webview/python-version.txt <<EOF
+          # Archive full versions from {{ archive_full_versions.results.0.item }}:
+          {{ archive_full_versions.results.0.stdout }}
+
+          # Publishing full versions from {{ publishing_full_versions.results.0.item }}:
+          {{ publishing_full_versions.results.0.stdout }}
+
+          # Legacy full versions from {{ legacy_full_versions.results.0.item }}:
+          {% for line in legacy_full_versions.results.0.stdout_lines[:-2] %}
+          {{ line }}
+          {% endfor %}
+          EOF
+      args:
+        executable: /bin/sh
+    - name: purge cached python-version.txt
+      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/python-version.txt'"
+
+- name: update history.txt
+  hosts: frontend
+  become: yes
+  become_user: www-data
+  tasks:
+    - shell:
+        cmd: |
+          cat /var/www/webview/version.txt >/var/tmp/history.txt.tmp
+          echo ------------------------------- >>/var/tmp/history.txt.tmp
+          cat /var/www/webview/python-version.txt >>/var/tmp/history.txt.tmp
+          echo =============================== >>/var/tmp/history.txt.tmp
+          echo >>/var/tmp/history.txt.tmp
+          cat /var/tmp/history.txt.tmp /var/tmp/history.txt >/var/tmp/history.txt.new
+          mv /var/tmp/history.txt.new /var/tmp/history.txt
+          cp /var/tmp/history.txt /var/www/webview/history.txt
+      args:
+        executable: /bin/sh
+    - name: purge cached history.txt
+      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/history.txt'"

--- a/zope.yml
+++ b/zope.yml
@@ -23,3 +23,6 @@
   tags:
     - zope
     - create_rhaptos_site
+
+- when: not_standalone is undefined
+  include: update_versions.yml


### PR DESCRIPTION
This creates `/var/www/webview/version.txt` on all the frontend servers
with versions of webview, archive, publishing, zope packages and the
date when version.txt was updated.  Future versions will be prepended to
version.txt (things on the top are most recent) so we get a list of what
version of packages were on the servers when.

An example version.txt that has been deployed once looks like this:

```
2017-10-06 14:08:39 PDT

webview==50042368add58b0cf4889ac5e37e8a55d09e1ef6

cnx-archive==2.6.1

cnx-publishing==0.9.3

-------------------------------
Archive full versions from staging07.cnx.org:
appdirs==1.4.3
Beaker==1.8.0
cnx-archive==2.6.1
cnx-db==0.10.4
cnx-epub==0.12.0
cnx-query-grammar==0.2.2
db-migrator==1.0.1
funcsigs==1.0.2
Jinja2==2.7.3
lxml==3.4.0
MarkupSafe==0.23
packaging==16.8
parsimonious==0.6.1
Paste==1.7.5.1
PasteDeploy==1.5.2
PasteScript==1.7.5
pkg-resources==0.0.0
psycopg2==2.7.3.1
pyparsing==2.2.0
pyramid==1.6a2
pyramid-jinja2==2.6.2
pyramid-multiauth==0.8.0
pyramid-sawing==1.1.2
pyramid-translogger==0.1
python-memcached==1.53
pytz==2017.2
PyYAML==3.12
repoze.lru==0.6
requests==2.7.0
rhaptos.cnxmlutils==1.3.0
sanction==0.4.1
six==1.10.0
translationstring==1.3
tzlocal==1.1.3
venusian==1.0
waitress==1.0.2
webencodings==0.5
WebOb==1.5.0a1
zope.deprecation==4.1.2
zope.interface==4.1.2

-------------------------------
Publishing full versions from staging08.cnx.org:
amqp==2.2.2
appdirs==1.4.3
Beaker==1.8.0
billiard==3.5.0.3
celery==4.1.0
cnx-archive==2.6.1
cnx-db==0.10.4
cnx-easybake==0.7.0
cnx-epub==0.12.0
cnx-publishing==0.9.3
cnx-query-grammar==0.2.2
cssselect==0.9.1
-e git+https://github.com/Connexions/cssselect2.git@560b4c432fcea05e4694ad6367b5a0e4d9fe2d33#egg=cssselect2
db-migrator==1.0.1
funcsigs==1.0.2
Jinja2==2.7.3
kombu==4.1.0
lxml==3.4.0
MarkupSafe==0.23
openstax-accounts==1.0.0
packaging==16.8
parsimonious==0.6.1
Paste==1.7.5.1
PasteDeploy==1.5.2
PasteScript==1.7.5
pkg-resources==0.0.0
psycopg2==2.7.3.1
pyparsing==2.2.0
pyramid==1.6a2
pyramid-jinja2==2.6.2
pyramid-multiauth==0.8.0
pyramid-sawing==1.1.2
pyramid-translogger==0.1
python-memcached==1.53
pytz==2017.2
PyYAML==3.12
repoze.lru==0.6
requests==2.7.0
rhaptos.cnxmlutils==1.3.0
sanction==0.4.1
six==1.10.0
SQLAlchemy==1.1.14
tinycss2==0.5
translationstring==1.3
tzlocal==1.1.3
venusian==1.0
vine==1.1.4
waitress==1.0.2
webencodings==0.5
WebOb==1.5.0a1
zope.deprecation==4.1.2
zope.interface==4.1.2

-------------------------------
Legacy full versions from staging04.cnx.org:
Jinja2==2.6
Pillow==1.7.6
Products.AdvancedQuery==2.2-rhaptosdev-r30378
Products.CMFDiffTool==0.3.3dev-r30461
Products.CMFSquidTool==1.5.1
Products.CNXCaching==0.2
Products.CNXContent==0.47
Products.CNXMLDocument==0.49
Products.CNXMLTransforms==0.23
Products.CNXPloneSite==0.76.2dev
Products.CacheSetup==1.2.1
Products.CatalogMemberDataTool==1.5
Products.ClockServer==0.2-Zope2.9dev
Products.ExtZSQL==0.9
Products.ExternalFile==0.1-rhaptosdev-r30470
Products.ExternalStorage==0.8.1
Products.FSImportTool==0.8
Products.FeatureArticle==0.10.1
Products.Five==1.4.5-rhaptosdev-r32037
Products.LensOrganizer==0.3.1
Products.Lensmaker==0.25
Products.Lineup==0.6
Products.LinkMapTool==0.9
Products.LocalFS==1.7-rhaptosdev-r30378
Products.ManagableIndex==1.7.3-rhaptosdev-r30378
Products.MasterSelectWidget==0.2.3-rhaptosdev-r30378
Products.MathEditor==0.4.1
Products.NoHeaderFieldContinuation==0.1-rhaptosdev-r30378
Products.OFolder==1.0-rhaptosdev-r30378
Products.PageCacheManager==1.2
Products.PloneHotfix20110531==2.0
Products.PloneHotfix20110720==1.2
Products.PloneHotfix20121106==1.2
Products.PloneHotfix20130618==1.1
Products.PolicyHTTPCacheManager==1.2
Products.References==0.10-rhaptosdev-r30378
Products.RhaptosBugTrackingTool==0.1.3
Products.RhaptosCacheTool==0.2.1
Products.RhaptosCatFixes==0.2
Products.RhaptosCollaborationTool==0.10.1
Products.RhaptosCollection==0.77
Products.RhaptosContent==0.66
Products.RhaptosHitCountTool==0.12
Products.RhaptosModuleEditor==0.84
Products.RhaptosModuleStorage==1.1.3
Products.RhaptosPDFLatexTool==0.15.1dev
Products.RhaptosPatchTool==0.7.2
Products.RhaptosPrint==0.104
Products.RhaptosRepository==1.4.2
Products.RhaptosSimilarityTool==0.13
Products.RhaptosSite==1.46
Products.RhaptosSword==2.3.2dev
Products.RhaptosTest==1.0
Products.RhaptosWorkgroup==0.27
Products.RisaCollection==0.1
Products.RisaHitCountTool==0.1
Products.RisaModuleEditor==0.1
Products.RisaModuleStorage==0.1
Products.RisaPDFLatexTool==0.1
Products.RisaPatchTool==0.1
Products.RisaRepository==0.1
Products.RisaSimilarityTool==0.1
Products.RisaSite==0.1
Products.RisaWorkgroup==0.1
Products.SimpleAttachment==3.0.1-rhaptosdev-r30378
Products.Siyavula==0.2
Products.UniFile==0.2
Products.ZAnnot==0.5
Products.ZPsycopgDA==2.4.6-rhaptos
Products.Zope-Hotfix-CVE-2010-3198==1.0
argparse==1.2.1
demjson==1.6
egenix-mx-base==3.2.5
elementtree==1.2.7-20070827-preview
lxml==3.3.6
plone.recipe.zope2instance==3.6
psycopg2==2.4.6
python-memcached==1.48
rhaptos.atompub.plone==0.2
rhaptos.cnxmlutils==1.2
rhaptos.mathjax==1.1
rhaptos.swordservice.plone==1.1
simplejson==1.9.2
zc.buildout==1.4.4
zc.recipe.egg==1.2.2

===============================

```

We might want to include `update_versions.yml` in the other playbooks like `archive.yml`, `frontend.yml` etc?