### PR TITLE
Add graylog settings to the qa variables

### DIFF
--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -39,6 +39,10 @@ accounts_domain: accounts-qa1.openstax.org
 tutor_domain: tutor-qa.openstax.org
 exercises_domain: exercises-qa.openstax.org
 
+# See group_vars/all.yml for defaults
+graylog_server: "{{ default_graylog_server }}"
+graylog_port: 5142
+
 accounts_consumer_token: "{{ vault_accounts_consumer_token }}"
 accounts_consumer_secret: "{{ vault_accounts_consumer_secret }}"
 accounts_disable_verify_ssl: no


### PR DESCRIPTION
We have set up syslog to forward logs to graylog if `graylog_server` and
`graylog_port` are defined.  So we just need to add the settings to the
qa environment group vars.
