### PR TITLE
Add "supervisorctl avail" before restart publishing handlers

### DIFF
--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -101,6 +101,7 @@
     requirements: "/var/lib/cnx/publishing-requirements.txt"
     virtualenv: "/var/cnx/venvs/publishing"
   notify:
+    - list supervisor applications
     - restart publishing
     - restart publishing workers
     - restart channel processing
@@ -150,6 +151,7 @@
     - "etc/cnx/publishing/logging.yaml"
     - "etc/cnx/publishing/vars.sh"
   notify:
+    - list supervisor applications
     - restart publishing
     - restart publishing workers
     - restart channel processing


### PR DESCRIPTION
When restarting publishing, publishing workers and channel processing,
we need to check whether they are installed in supervisor by using
`supervisorctl avail`.  This is in the "list supervisor applications"
handler which needs to be explicitly included.  The error message when
deploying using publishing.yml or main.yml:

```
The conditional check 'supervisorctl_avail.stdout.find('publishing:') != -1'
failed. The error was: error while evaluating conditional
(supervisorctl_avail.stdout.find('publishing:') != -1):
'supervisorctl_avail' is undefined
```

---
The conditional check for restarting publishing was in a handler that probably got evaluated in ansible v2.3 but stopped working in ansible v2.4.  I guess it makes sense the handler needs to be explicitly called.