### PR TITLE
Change "include" to "import_tasks" or "import_playbook"

### DIFF
--- a/configure_hosts.yml
+++ b/configure_hosts.yml
@@ -1,7 +1,7 @@
 ---
 # Configure /etc/hosts file for development.
 
-- include: pretask.yml
+- import_playbook: pretask.yml
 
 - name: "configure /etc/hosts file"
   hosts:

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -42,7 +42,7 @@
     dbmigrate_context_args: "{{ migration_contexts|default('--context cnx-publishing --context cnx-archive') }}"
     db_connection_string: "dbname={{ db_name }} user=postgres host=localhost port=5432"
   tasks:
-    - include: tasks/create_db.yml
+    - import_tasks: tasks/create_db.yml
       vars:
         db_owner: "postgres"
     - name: pipe database in

--- a/database.yml
+++ b/database.yml
@@ -22,7 +22,7 @@
   hosts:
     - database
   tasks:
-    - include: tasks/create_db_user.yml
+    - import_tasks: tasks/create_db_user.yml
       vars:
         db_user: "{{ archive_db_user }}"
         db_password: "{{ archive_db_password }}"
@@ -34,25 +34,25 @@
         #       This is to be correct in cnx-db and db-migrator.
         #       In the mean time use xxx_archive_db_user_role_attr_flags.
         role_attr_flags: "{{ xxx_archive_db_user_role_attr_flags|default('CREATEDB,NOSUPERUSER') }}"
-    - include: tasks/create_db.yml
+    - import_tasks: tasks/create_db.yml
       vars:
         db_owner: "{{ archive_db_user }}"
         db_name: "{{ archive_db_name }}"
-    - include: tasks/create_db_user.yml
+    - import_tasks: tasks/create_db_user.yml
       when: authoring_db_user is defined
       vars:
         db_user: "{{ authoring_db_user }}"
         db_password: "{{ authoring_db_password }}"
-    - include: tasks/create_db_user.yml
+    - import_tasks: tasks/create_db_user.yml
       vars:
         db_user: "backups"
         role_attr_flags: ""
-    - include: tasks/create_db.yml
+    - import_tasks: tasks/create_db.yml
       when: authoring_db_user is defined
       vars:
         db_owner: "{{ authoring_db_user }}"
         db_name: "{{ authoring_db_name }}"
-    - include: tasks/create_db_user.yml
+    - import_tasks: tasks/create_db_user.yml
       vars:
         db_user: "{{ replicator_db_user|default(default_replicator_db_user) }}"
         role_attr_flags: "replication"

--- a/main.yml
+++ b/main.yml
@@ -1,7 +1,7 @@
 ---
 # Used to setup a deployment on localhost.
 
-- include: pretask.yml
+- import_playbook: pretask.yml
 
 - name: "notify #cnx-stream of the deployment (start)"
   hosts: all
@@ -11,29 +11,29 @@
       - "#cnx-stream"
       - "#deployments"
   tasks:
-    - include: tasks/notify_slack.yml
+    - import_tasks: tasks/notify_slack.yml
 
 # +++
 # Persistence services
 # +++
 
-- include: nfs.yml
-- include: nfs_connected.yml
+- import_playbook: nfs.yml
+- import_playbook: nfs_connected.yml
 
-- include: database.yml
-- include: broker.yml
+- import_playbook: database.yml
+- import_playbook: broker.yml
 
 # +++
 # Applications
 # +++
 
-- include: archive.yml
-- include: publishing.yml
-- include: channel_processing.yml
-- include: publishing_worker.yml
-- include: authoring.yml
+- import_playbook: archive.yml
+- import_playbook: publishing.yml
+- import_playbook: channel_processing.yml
+- import_playbook: publishing_worker.yml
+- import_playbook: authoring.yml
 
-- include: zope.yml
+- import_playbook: zope.yml
   tags:
     - zope
     - zeo
@@ -42,27 +42,27 @@
     - legacy_be
     - be
 
-- include: legacy_frontend.yml
+- import_playbook: legacy_frontend.yml
   tags:
     - haproxy
     - varnish
     - legacy_fe
     - fe
 
-- include: frontend.yml
+- import_playbook: frontend.yml
   tags:
     - nginx
     - varnish
     - webview
     - fe
 
-- include: lead_frontend.yml
+- import_playbook: lead_frontend.yml
   tags:
     - haproxy
     - lead_fe
     - fe
 
-- include: iptables.yml
+- import_playbook: iptables.yml
   tags:
     - iptables
     - firewall
@@ -75,4 +75,4 @@
       - "#cnx-stream"
       - "#deployments"
   tasks:
-    - include: tasks/notify_slack.yml
+    - import_tasks: tasks/notify_slack.yml

--- a/nfs.yml
+++ b/nfs.yml
@@ -13,7 +13,7 @@
   hosts: nfs
   become: yes
   tasks:
-    - include: tasks/connect_nfs.yml
+    - import_tasks: tasks/connect_nfs.yml
     - name: install nfs-kernel-server
       apt:
         name: nfs-kernel-server

--- a/nfs_connected.yml
+++ b/nfs_connected.yml
@@ -4,4 +4,4 @@
 - name: connect to nfs
   hosts: nfs_connected
   tasks:
-    - include: tasks/connect_nfs.yml
+    - import_tasks: tasks/connect_nfs.yml

--- a/push_data.yml
+++ b/push_data.yml
@@ -67,7 +67,7 @@
 - name: forcibly push data
   hosts: database
   tasks:
-    - include: tasks/create_db_user.yml
+    - import_tasks: tasks/create_db_user.yml
       vars:
         role_attr_flags: 'SUPERUSER'
     - name: drop database

--- a/roles/cnx_database/tasks/main.yml
+++ b/roles/cnx_database/tasks/main.yml
@@ -14,9 +14,9 @@
     path: "{{ _pg_pkglibdir.stdout }}/session_exec.so"
   register: session_exec_so
 
-- include: install_plxslt.yml
+- import_tasks: install_plxslt.yml
   when: not plxslt_so.stat.exists
-- include: install_session_exec.yml
+- import_tasks: install_session_exec.yml
   when: not session_exec_so.stat.exists
 
-- include: plpython_imports.yml
+- import_tasks: plpython_imports.yml

--- a/roles/python24/tasks/main.yml
+++ b/roles/python24/tasks/main.yml
@@ -4,5 +4,5 @@
 - stat: path=/usr/local/bin/python2.4
   register: python24_binary
 
-- include: tasks/install_python24.yml
+- import_tasks: tasks/install_python24.yml
   when: not python24_binary.stat.exists

--- a/roles/webview/tasks/main.yml
+++ b/roles/webview/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # Installs webview with all the dependencies.
 
-- include: webview.yml
+- import_tasks: webview.yml
   tags:
     - webview
 
-- include: google_site_verification.yml
+- import_tasks: google_site_verification.yml
   tags:
     - google-site-verification

--- a/roles/zope_common/tasks/main.yml
+++ b/roles/zope_common/tasks/main.yml
@@ -34,6 +34,6 @@
     - "postgresql-client-{{ postgres_version }}"
     - "libpq-dev"
 
-- include: configure_buildout.yml
-- include: install_cnx_buildout.yml
-- include: pdf_gen_dependencies.yml
+- import_tasks: configure_buildout.yml
+- import_tasks: install_cnx_buildout.yml
+- import_tasks: pdf_gen_dependencies.yml

--- a/swap_datafs.yml
+++ b/swap_datafs.yml
@@ -54,9 +54,9 @@
       args:
         chdir: "/var/lib/cnx/cnx-buildout"
     - name: update pdf_gen settings
-      include: tasks/assign_pdf_gen_settings.yml
+      import_tasks: tasks/assign_pdf_gen_settings.yml
     - name: set up localFS PDF folders
-      include: tasks/set_up_localfs_folders.yml
+      import_tasks: tasks/set_up_localfs_folders.yml
 
 - name: start zclient applications
   hosts: zclient

--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -14,7 +14,7 @@
     db_owner: "{{ archive_db_user }}"
     db_host: "{{ archive_db_host }}"
     db_port: "{{ archive_db_port }}"
-  include: tasks/create_db.yml
+  import_tasks: tasks/create_db.yml
 
 - name: create rhaptos site
   when: rhaptos_site|failed
@@ -38,7 +38,7 @@
 
 - name: assign pdf_gen settings
   when: rhaptos_site|failed
-  include: tasks/assign_pdf_gen_settings.yml
+  import_tasks: tasks/assign_pdf_gen_settings.yml
   tags:
     - zope
     - assign_pdf_gen_settings

--- a/zope.yml
+++ b/zope.yml
@@ -14,11 +14,11 @@
 - name: create site
   hosts: zope
   tasks:
-    - include: tasks/create_rhaptos_site.yml
+    - import_tasks: tasks/create_rhaptos_site.yml
       run_once: yes
-    - include: tasks/set_up_localfs_folders.yml
+    - import_tasks: tasks/set_up_localfs_folders.yml
       run_once: yes
-    - include: tasks/set_up_rhaptos_print_host.yml
+    - import_tasks: tasks/set_up_rhaptos_print_host.yml
       run_once: yes
   tags:
     - zope


### PR DESCRIPTION
The use of `include:` is deprecated in ansible v2.4.0 and will be
removed in v2.8:

```
[DEPRECATION WARNING]: 'include' for playbook includes. You should use 'import_playbook' instead. This feature will be removed in version 2.8. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature
will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale..
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

`include:` was used for dynamic and static reusable content, this has
now been separated into `import*` for static and `include*` for dynamic.

(The following is copied from
http://docs.ansible.com/ansible/latest/playbooks_reuse.html)

Differences Between Static and Dynamic

The two modes of operation are pretty simple:

 - Ansible pre-processes all static imports during Playbook parsing time.
 - Dynamic includes are processed during runtime at the point in which that
   task is encountered.

When it comes to Ansible task options like `tags` and conditional statements
(`when`:):

 - For static imports, the parent task options will be copied to all child
   tasks contained within the import.
 - For dynamic includes, the task options will only apply to the dynamic task
   as it is evaluated, and will not be copied to child tasks.