### PR TITLE
Got the syntax for multi-queue wrong

### DIFF
--- a/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
+++ b/roles/publishing_worker/templates/etc/supervisor/conf.d/publishing_celery_workers.conf
@@ -1,7 +1,7 @@
 {% for i in range(0, hostvars[inventory_hostname].publishing_worker_count|default(1), 1) %}
 [program:publishing_celery_worker{{ i }}]
 environment=PYRAMID_INI="/etc/cnx/publishing/app.ini"
-command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing -Q default -Q deferred
+command=/var/cnx/venvs/publishing/bin/celery worker -A cnxpublishing -Q default,deferred
 user=www-data
 
 {% endfor %}


### PR DESCRIPTION
MY fault. Should be comma-separated list. QA was only listening to `deferred` queue
http://docs.celeryproject.org/en/latest/reference/celery.bin.worker.html#cmdoption-celery-worker-q

Commandline way to verify this (name is last thing on the end of the line):
```
export  PYRAMID_INI=/etc/cnx/publishing/app.ini
/var/cnx/venvs/publishing/bin/python2 /var/cnx/venvs/publishing/bin/celery -A cnxpublishing inspect active_queues
-> celery@staging08: OK
    * {u'no_declare': None, u'exclusive': False, u'max_priority': None, u'exchange': {u'no_declare': False, u'name': u'default', u'durable': True, u'delivery_mode': None, u'passive': False, u'arguments': None, u'type': u'direct', u'auto_delete': False}, u'auto_delete': False, u'expires': None, u'routing_key': u'default', u'no_ack': False, u'alias': None, u'message_ttl': None, u'max_length': None, u'max_length_bytes': None, u'binding_arguments': None, u'queue_arguments': None, u'bindings': [], u'consumer_arguments': None, u'durable': True, u'name': u'default'}
    * {u'no_declare': None, u'exclusive': False, u'max_priority': None, u'exchange': {u'no_declare': False, u'name': u'default', u'durable': True, u'delivery_mode': None, u'passive': False, u'arguments': None, u'type': u'direct', u'auto_delete': False}, u'auto_delete': False, u'expires': None, u'routing_key': u'default', u'no_ack': False, u'alias': None, u'message_ttl': None, u'max_length': None, u'max_length_bytes': None, u'binding_arguments': None, u'queue_arguments': None, u'bindings': [], u'consumer_arguments': None, u'durable': True, u'name': u'deferred'}
```