### PR TITLE
Add cnx-recipes to all the publishing environments

### DIFF
--- a/environments/__dev_envs/files/publishing-requirements.txt
+++ b/environments/__dev_envs/files/publishing-requirements.txt
@@ -7,6 +7,7 @@ db-migrator==1.0.2
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
+-e git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.3

--- a/environments/des/files/publishing-requirements.txt
+++ b/environments/des/files/publishing-requirements.txt
@@ -7,6 +7,7 @@ db-migrator==1.0.2
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
+-e git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.3

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -3,6 +3,7 @@ Beaker==1.9.0
 cnx-archive==2.6.1
 cnx-db==0.10.4
 cnx-easybake==0.7.0
+cnx-recipes==1.0.1
 cnx-epub==0.12.0
 cnx-publishing==0.9.3
 cnx-query-grammar==0.2.2

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -3,6 +3,7 @@ Beaker==1.9.0
 cnx-archive==2.6.1
 cnx-db==0.10.4
 cnx-easybake==0.7.0
+cnx-recipes==1.0.1
 cnx-epub==0.12.0
 cnx-publishing==0.9.3
 cnx-query-grammar==0.2.2

--- a/environments/vm/files/publishing-requirements.txt
+++ b/environments/vm/files/publishing-requirements.txt
@@ -7,6 +7,7 @@ db-migrator==1.0.2
 
 -e git+https://github.com/Connexions/openstax-accounts.git#egg=openstax-accounts
 -e git+https://github.com/Connexions/cnx-publishing.git#egg=cnx-publishing
+-e git+https://github.com/Connexions/cnx-recipes.git#egg=cnx-recipes
 
 # Deployment specific dependencies
 pyramid_sawing==1.1.3


### PR DESCRIPTION
Add cnx-recipes 1.0.1 package (or tip of master, as appropriate) to all the publishing environments.