### PR TITLE
Forward /static/ to publishing in varnish.vcl

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -167,7 +167,7 @@ sub vcl_recv {
 
 {% endif %}
     # cnx rewrite archive
-    if (req.url ~ "^/a/") {
+    if (req.url ~ "^/a/" || req.url ~ "^/static/") {
         set req.backend_hint = publishing_cluster.backend(req.http.cookie);
         return (pass);
     }


### PR DESCRIPTION
Publishing has static files like css and javascript files that are
currently 404 not found because varnish does not have routes for
`/static/`.

Add `req.url ~ "^/static/"` to varnish.vcl and use publishing as the
backend.