### PR TITLE
Change acquire_data inventory data_source to prod10

### DIFF
--- a/environments/acquire_data/inventory
+++ b/environments/acquire_data/inventory
@@ -1,5 +1,5 @@
 [data_source]
-tundra.cnx.rice.edu
+prod10.cnx.org
 
 [data_source:vars]
 nice_priority=19


### PR DESCRIPTION
The production database used to be on tundra, but since we deployed
production using cnx-deploy, the database is now on prod09 with
replication on prod10.  So changing acquire_data to use prod10.