### PR TITLE
Upgrade cnx packages for prod and staging

### DIFF
--- a/environments/prod/files/archive-requirements.txt
+++ b/environments/prod/files/archive-requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==2.6.1
-cnx-db==0.10.4
+cnx-archive==2.7.0
+cnx-db==0.11.0
 cnx-epub==0.12.0
 cnx-query-grammar==0.2.2
 db-migrator==1.0.2

--- a/environments/prod/files/publishing-requirements.txt
+++ b/environments/prod/files/publishing-requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==2.6.1
-cnx-db==0.10.4
+cnx-archive==2.7.0
+cnx-db==0.11.0
 cnx-easybake==0.7.0
 cnx-recipes==1.0.1
 cnx-epub==0.12.0

--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -68,7 +68,7 @@ nfs_mounts:
 
 nfs_connections: "{{ vault_nfs_connections }}"
 
-webview_version: v0.23.2
+webview_version: v0.23.3
 
 google_site_verification_filename: "{{ vault_google_site_verification_filename }}"
 

--- a/environments/staging/files/archive-requirements.txt
+++ b/environments/staging/files/archive-requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==2.6.1
-cnx-db==0.10.4
+cnx-archive==2.7.0
+cnx-db==0.11.0
 cnx-epub==0.12.0
 cnx-query-grammar==0.2.2
 db-migrator==1.0.2

--- a/environments/staging/files/publishing-requirements.txt
+++ b/environments/staging/files/publishing-requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==2.6.1
-cnx-db==0.10.4
+cnx-archive==2.7.0
+cnx-db==0.11.0
 cnx-easybake==0.7.0
 cnx-recipes==1.0.1
 cnx-epub==0.12.0

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -69,7 +69,7 @@ nfs_mounts:
 
 nfs_connections: "{{ vault_nfs_connections }}"
 
-webview_version: v0.23.2
+webview_version: v0.23.3
 
 blocked_ip_addresses: "{{ vault_blocked_ip_addresses }}"
 


### PR DESCRIPTION
cnx-archive 2.6.1 -> 2.7.0
- Use cnx-db docker image in travis tests (Connexions/cnx-archive#521)
- update test data and tests for subcol uuids and fulltext-book search (Connexions/cnx-archive#529)
- Fix update latest trigger tests to use legacy version in inserts
- Install tzdata for cnx-archive docker image
- Update book search test following changes in book search sql
- In book search to provide query_type parameterization for AND vs OR queries (Connexions/cnx-archive#532)

cnx-db 0.10.4 -> 0.11.0

- In book search to provide query_type parameterization for AND vs OR queries (Connexions/cnx-db#87)
- :bug: Fix number of migrations to rollback in ci_test_migrations.sh
- Books containing this page in /extras/pageid
    ( get only the highest version for each book a page is in, return full ident_hash, as well as authors. Put same-as-page-authors first, since this is likely to be the original book the page was published in. Returned as list of hashes in page content-extras)
- :bug: Correct project testing requirements to also use main.txt (Connexions/cnx-db#85)
- :bug: !!! Fix update latest trigger not adding new modules
- ~make in book search OR terms, rather than AND them~ (superseded by query_type) 
- :bug: do not use timestamps to determine latest content (Connexions/cnx-db#75)
- Add migration for print_style_recipes (installs recipes in database) (Connexions/cnx-db#80)
- :bug: Make lexeme removal migration idempotent (Connexions/cnx-db#82)
- :bug: Fix print_style_recipe trigger definition to align with the migration (Connexions/cnx-db#81)
- Provide book full text search (Connexions/cnx-db#78)

webview 0.23.2 -> 0.23.3

- Merge pull request #1586 from Connexions/upgrade-deps
- :arrow_down: less
- :arrow_up: grunt-mocha
- :arrow_up: upgrade jsdom
- :arrow_up: deps