### PR TITLE
Filter out all haproxy health check from archive and publishing logs

### DIFF
--- a/archive.yml
+++ b/archive.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: collect info on frontend hosts
+  hosts:
+    - lead_frontend
+    - frontend
+    - legacy_frontend
+  # NOOP only to acquire IP address information about connected hosts,
+  # needed for rsyslog config
+  tasks: []
+  tags:
+    - collect-info
+
 - name: install archive
   hosts: archive
   roles:

--- a/publishing.yml
+++ b/publishing.yml
@@ -1,5 +1,16 @@
 ---
 
+- name: collect info on frontend hosts
+  hosts:
+    - lead_frontend
+    - frontend
+    - legacy_frontend
+  # NOOP only to acquire IP address information about connected hosts,
+  # needed for rsyslog config
+  tasks: []
+  tags:
+    - collect-info
+
 - name: install publishing
   hosts: publishing
   roles:

--- a/roles/archive/templates/etc/rsyslog.d/10-archive.conf
+++ b/roles/archive/templates/etc/rsyslog.d/10-archive.conf
@@ -5,4 +5,4 @@ input(type="imfile"
       Tag="cnxarchive"
       Severity="info")
 
-if $syslogtag == "cnxarchive" and ({% for host in groups.lead_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~
+if $syslogtag == "cnxarchive" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~

--- a/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
+++ b/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
@@ -5,4 +5,4 @@ input(type="imfile"
       Tag="cnxpublishing"
       Severity="info")
 
-if $syslogtag == "cnxpublishing" and ({% for host in groups.lead_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~
+if $syslogtag == "cnxpublishing" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~


### PR DESCRIPTION
Archive and publishing rsyslog config filters out haproxy health check
requests from `lead_frontend`, but there are other servers with haproxy
installed.  The graylog stream for staging is showing health checks from
frontend (nginx) and legacy frontend (haproxy), so we need to exclude
these requests as well.