### PR TITLE
Forward `^/sitemap.*.xml` requests to archive

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -173,7 +173,7 @@ sub vcl_recv {
     }
 
     # cnx rewrite archive  - specials served from nginx statically
-    if (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.xml" || req.url ~ "^/robots.txt") {
+    if (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml" || req.url ~ "^/robots.txt") {
         if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
             set req.backend_hint = publishing_cluster.backend(req.http.cookie);
             return (pass);


### PR DESCRIPTION
Individual sitemap.xml have a limit of 50,000 URLs and 50MB.  If a site
has more URLs, a sitemap_index.xml can be used to include more sitemap
xml files.  We have added `sitemap_index.xml` and
`sitemap-{from_id}.xml` (e.g. `sitemap-8515.xml`) in archive and this
needs to be in the varnish config so archive is used to handle the
sitemap requests.