### PR TITLE
- Update cnx package on prod and staging

### DIFF
--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -5,7 +5,7 @@ cnx-db==0.12.0
 cnx-easybake==0.7.0
 cnx-recipes==1.1.0
 cnx-epub==0.12.0
-cnx-publishing==0.9.4
+cnx-publishing==0.9.5
 cnx-query-grammar==0.2.2
 cssselect==1.0.1
 -e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2


### PR DESCRIPTION
    cnx-publishing 0.9.4 -> 0.9.5:
       - fix packaging error for static files

This fixes issue @kerwinso found regarding missing CSS for `/a/content-status` view