### PR TITLE
Explicitly set index url to https pypi for pip 2.4

### DIFF
--- a/roles/zope_common/tasks/install_cnx_buildout.yml
+++ b/roles/zope_common/tasks/install_cnx_buildout.yml
@@ -92,6 +92,7 @@
     version: 1.9.2
     virtualenv: "/var/cnx/venvs/cnx-buildout"
     virtualenv_python: python2
+    extra_args: --index-url=https://pypi.python.org/simple/
 
 - name: run buildout
   become: yes
@@ -101,7 +102,7 @@
 
 - name: install lxml 3.2.1
   become: yes
-  shell: ". bin/libs.sh && /var/cnx/venvs/cnx-buildout/bin/pip install lxml==3.2.1"
+  shell: ". bin/libs.sh && /var/cnx/venvs/cnx-buildout/bin/pip install --index-url=https://pypi.python.org/simple/ lxml==3.2.1"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
 
@@ -111,6 +112,7 @@
     name: "{{ item.name }}"
     version: "{{ item.version }}"
     executable: pip-2.4
+    extra_args: --index-url=https://pypi.python.org/simple/
   with_items:
     - name: python-memcached
       version: 1.48

--- a/tasks/install_python24.yml
+++ b/tasks/install_python24.yml
@@ -98,3 +98,4 @@
   become: yes
   pip:
     name: readline
+    extra_args: --index-url=https://pypi.python.org/simple/


### PR DESCRIPTION
Pypi does not allow http access anymore, and easy install doesn't seem
to follow redirects so we need to explicitly set the index url to
https://pypi.python.org/simple/ for buildout to work.