### PR TITLE
reduce haproy check load on zope

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -43,7 +43,7 @@
         # "rise 1" means consider the frontend up after 1 successful health check
       {% for host in groups.frontend %}
       {% set ip_addr = hostvars[host].ansible_default_ipv4.address %}
-        server {{ host }} {{ ip_addr }}:{{ varnish_port }} check rise 1
+        server {{ host }} {{ ip_addr }}:{{ varnish_port }} check inter 30s rise 1
       {% endfor %}
 
       # Load balancing the frontend grouping
@@ -57,7 +57,7 @@
         # "rise 1" means consider the frontend up after 1 successful health check
       {% for host in groups.legacy_frontend %}
       {% set ip_addr = hostvars[host].ansible_default_ipv4.address %}
-        server {{ host }} {{ ip_addr }}:{{ varnish_port }} check rise 1
+        server {{ host }} {{ ip_addr }}:{{ varnish_port }} check inter 30s rise 1
       {% endfor %}
     owner: root
     group: root

--- a/roles/zclient_load_balancer/tasks/main.yml
+++ b/roles/zclient_load_balancer/tasks/main.yml
@@ -34,7 +34,7 @@
       {% for host in groups.zclient %}
       {% set ip_addr = hostvars[host].ansible_default_ipv4.address %}
       {% for i in range(0, hostvars[host].zclient_count|default(1), 1) %}
-        server {{ host }}{{ i }} {{ ip_addr }}:{{ base_port + i }} check maxconn 4 rise 1
+        server {{ host }}{{ i }} {{ ip_addr }}:{{ base_port + i }} check inter 30s maxconn 4 rise 1
       {% endfor %}
       {% endfor %}
 
@@ -45,7 +45,7 @@
       {% set host = item.host %}
       {# Note, legacy zope client ports increment by one hundred #}
       {% for i in range(0, item.count+1, 1) %}
-        server {{ host }}{{ i }} {{ ip_addr }}:8{{ '{0:0>3}'.format(100*i+80) }} check maxconn 4 rise 1
+        server {{ host }}{{ i }} {{ ip_addr }}:8{{ '{0:0>3}'.format(100*i+80) }} check inter 30s maxconn 4 rise 1
       {% endfor %}
       {% endfor %}
       {# /FIXME phased-deploy #}


### PR DESCRIPTION
Zope is fairly slow to respond, even to OPTION - reduce haproxy
alive checks from every 2s to every 30s
There's similar checks going to varnish for the 'lead' load balance, ~but I think varnish may be more able to handle it.~ which varnish passes right through, so hit those as well.