### PR TITLE
Bump cnx package versions for next deploy

### DIFF
--- a/environments/__prod_envs/files/archive-requirements.txt
+++ b/environments/__prod_envs/files/archive-requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==3.0.0
+cnx-archive==3.1.0
 cnx-db==1.1.0
 cnx-epub==0.12.0
 cnx-query-grammar==0.2.2

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.4.0
 Beaker==1.9.0
-cnx-archive==3.0.0
+cnx-archive==3.1.0
 cnx-db==1.1.0
 cnx-easybake==0.7.0
 cnx-recipes==1.1.0

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -5,7 +5,7 @@ cnx-db==1.1.0
 cnx-easybake==0.7.0
 cnx-recipes==1.1.0
 cnx-epub==0.12.0
-cnx-publishing==0.9.5
+cnx-publishing==0.10.0
 cnx-query-grammar==0.2.2
 cssselect==1.0.1
 -e git+https://github.com/Connexions/cssselect2.git#egg=cssselect2


### PR DESCRIPTION
cnx-publishing:
> 0.10.0
> ------
> 
> - Fix link to display None for print-styles without a recipe (#209 & #210)
> - Add print style view recipe information. (#201)
> - Add ability to unbake even in the presence of previous succcessful bake. (#204)
> - Change config files db settings to use postgresql:// urls. (#203)

cnx-archive:
>3.1.0
>-----
>
>- Add list of books containing the in context page to ``/extras/{ident_hash}``. (#502)