### PR TITLE
Symlink staging and prod files to prod_envs files

### DIFF
--- a/environments/prod/files
+++ b/environments/prod/files
@@ -1,0 +1,1 @@
+../__prod_envs/files/

--- a/environments/staging/files
+++ b/environments/staging/files
@@ -1,0 +1,1 @@
+../__prod_envs/files/


### PR DESCRIPTION
We merged the staging and prod files into `__prod_envs/files/` because
they should be the same.  But somehow the symlink is missing, so we are
adding this now.