### PR TITLE
Set use_ssh_args to yes in synchronize task

### DIFF
--- a/roles/zope_common/tasks/install_cnx_buildout.yml
+++ b/roles/zope_common/tasks/install_cnx_buildout.yml
@@ -64,6 +64,7 @@
     dest: "/var/lib/cnx/cnx-buildout"
     owner: no
     group: no
+    use_ssh_args: yes
   tags: buildout-copy
 
 - name: ensure proper ownership of buildout


### PR DESCRIPTION
On bastion2, we defined `ssh_args` in ansible.cfg, which also needs to
apply to rsync.  Otherwise we have errors like this:

```
TASK [zope_common : copy cached python packages downloads directory]
*********************************************************************************************************
fatal: [staging06.cnx.org]: FAILED! => {"changed": false, "cmd":
"/usr/bin/rsync --delay-updates -F --compress --archive --no-owner
--no-group --rsh=/usr/bin/ssh -S none -o StrictHostKeyChecking=no -o
UserKnownHostsFile=/dev/null --rsync-path=sudo rsync
--out-format=<<CHANGED>>%i %n%L
/var/cnx-deploy/files/src/cnx-buildout/downloads
staging06.cnx.org:/var/lib/cnx/cnx-buildout", "failed": true, "msg":
"Warning: Permanently added 'staging06.cnx.org' (ECDSA) to the list of
known hosts.\r\nPermission denied (publickey).\r\nrsync: connection
unexpectedly closed (0 bytes received so far) [sender]\nrsync error:
error in rsync protocol data stream (code 12) at io.c(226)
[sender=3.1.1]\n", "rc": 12}
```