### PR TITLE
Change robots.txt become_user to template owner

### DIFF
--- a/roles/robots_txt/tasks/main.yml
+++ b/roles/robots_txt/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: Add robots.txt
   become: yes
-  become_user: www-data
   template:
     src: var/www/webview/robots.txt
     dest: /var/www/webview/robots.txt
+    owner: www-data


### PR DESCRIPTION
It seems using `become_user` together with `template` does not work when
`become_user` is not root:

```
TASK [robots_txt : Add robots.txt] *******************************************************************************************************************************************
fatal: [staging01.cnx.org]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/tmp/ansible-tmp-1510787806.71-109822540826262/': Operation not permitted\nchown: changing ownership of '/tmp/ansible-tmp-1510787806.71-109822540826262/source': Operation not permitted\n}). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}
```

Remove `become_user` and change it to set the robots.txt file owner as
`www-data` instead.