### PR TITLE
Change "include" to "import_tasks" or "import_playbook"

### DIFF
--- a/archive.yml
+++ b/archive.yml
@@ -20,4 +20,4 @@
     - be
 
 - when: not_standalone is undefined
-  include: update_versions.yml
+  import_playbook: update_versions.yml

--- a/frontend.yml
+++ b/frontend.yml
@@ -33,4 +33,4 @@
 #    - fe
 
 - when: not_standalone is undefined
-  include: update_versions.yml
+  import_playbook: update_versions.yml

--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -26,7 +26,7 @@
         module: stat
         path: "{{ cert_pem_filepath }}"
       register: pem_file
-    - include: tasks/create_self_signed_cert.yml
+    - import_tasks: tasks/create_self_signed_cert.yml
       delegate_to: 127.0.0.1
       when: not pem_file.stat.exists
   run_once: yes

--- a/main.yml
+++ b/main.yml
@@ -67,7 +67,7 @@
     - iptables
     - firewall
 
-- include: update_versions.yml
+- import_playbook: update_versions.yml
 
 - name: "notify #cnx-stream of the deployment (end)"
   hosts: all

--- a/publishing.yml
+++ b/publishing.yml
@@ -20,4 +20,4 @@
     - be
 
 - when: not_standalone is undefined
-  include: update_versions.yml
+  import_playbook: update_versions.yml

--- a/zope.yml
+++ b/zope.yml
@@ -25,4 +25,4 @@
     - create_rhaptos_site
 
 - when: not_standalone is undefined
-  include: update_versions.yml
+  import_playbook: update_versions.yml


### PR DESCRIPTION
The use of `include:` is deprecated in ansible v2.4.0 and will be
removed in v2.8:

```
[DEPRECATION WARNING]: 'include' for playbook includes. You should use 'import_playbook' instead. This feature will be removed in version 2.8. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature
will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale..
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

`include:` was used for dynamic and static reusable content, this has
now been separated into `import*` for static and `include*` for dynamic.

(The following is copied from
http://docs.ansible.com/ansible/latest/playbooks_reuse.html)

Differences Between Static and Dynamic

The two modes of operation are pretty simple:

 - Ansible pre-processes all static imports during Playbook parsing time.
 - Dynamic includes are processed during runtime at the point in which that
   task is encountered.

When it comes to Ansible task options like `tags` and conditional statements
(`when`:):

 - For static imports, the parent task options will be copied to all child
   tasks contained within the import.
 - For dynamic includes, the task options will only apply to the dynamic task
   as it is evaluated, and will not be copied to child tasks.

----

Sorry I accidentally added `include:` when I did the version.txt PR... :(