### PR TITLE
Remove postgres superuser privileges from db user

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -26,14 +26,6 @@
       vars:
         db_user: "{{ archive_db_user }}"
         db_password: "{{ archive_db_password }}"
-        # FIXME (8-Mar-12017) db-role-perms:
-        #       New databases and migrations currently
-        #       require the user to have superuser privileges.
-        #       This is only required for database
-        #       initialization and migrations.
-        #       This is to be correct in cnx-db and db-migrator.
-        #       In the mean time use xxx_archive_db_user_role_attr_flags.
-        role_attr_flags: "{{ xxx_archive_db_user_role_attr_flags|default('CREATEDB,NOSUPERUSER') }}"
     - import_tasks: tasks/create_db.yml
       vars:
         db_owner: "{{ archive_db_user }}"

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -6,7 +6,6 @@ archive_db_user: cnxarchive
 archive_db_password: cnxarchive
 archive_db_host: localhost
 archive_db_port: 5432
-xxx_archive_db_user_role_attr_flags: 'SUPERUSER'
 
 publishing_broker_user: cnxpublishing
 publishing_broker_password: cnxpublishing

--- a/roles/repository_db/handlers/main.yml
+++ b/roles/repository_db/handlers/main.yml
@@ -3,22 +3,45 @@
 # Note, the setup current **assumes** that the publishing and archive database
 # is the same database. There has been no reason to split these yet, so we won't.
 
+- name: initialize repository database (create superuser)
+  become: yes
+  become_user: postgres
+  postgresql_user:
+    db: postgres
+    login_host: "{{ archive_db_host }}"
+    port: "{{ archive_db_port }}"
+    login_user: postgres
+    name: "super_{{ archive_db_user }}"
+    password: "{{ archive_db_password }}"
+    role_attr_flags: "SUPERUSER"
+  listen: initialize repository database
+
 - name: initialize repository database (cnx-db init)
   environment:
     DB_URL: "postgresql://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
-    DB_SUPER_URL: "postgresql://postgres@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
+    DB_SUPER_URL: "postgresql://super_{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
   command: "/var/cnx/venvs/publishing/bin/cnx-db init"
   listen: initialize repository database
 
 - name: initialize repository database (cnx-db venv)
   environment:
     DB_URL: "postgresql://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
-    DB_SUPER_URL: "postgresql://postgres@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
+    DB_SUPER_URL: "postgresql://super_{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"
   command: "/var/cnx/venvs/publishing/bin/cnx-db venv"
   listen: initialize repository database
 
-- name: initialize repository database (dbmigrator init)
+- name: initialize repository database (reassign owner)
   environment:
+    # If PGHOST is not set, psql tries to look for cluster "main" which doesn't
+    # work:
+    #     $ psql -U postgres -l
+    #     Error: Invalid data directory
+    # This appears to be a problem after a postgresql-common update
+    PGHOST: "{{ archive_db_host }}"
+  command: "psql -U postgres {{ archive_db_name }} -c 'REASSIGN OWNED BY super_{{ archive_db_user }} TO {{ archive_db_user }}; DROP USER super_{{ archive_db_user }};'"
+  listen: initialize repository database
+
+- name: initialize repository database (dbmigrator init)
   command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/publishing/app.ini --context cnx-db init"
   listen: initialize repository database
 


### PR DESCRIPTION
When initializing the schema, there are some functions that require
postgres superuser privileges to create.  But we don't really want the
db user to have superuser privileges.

Create a temporary super user for `cnx-db init` and `cnx-db venv` and
then reassign everything to the db user.