### PR TITLE
Use delegated facts instead of NOOP to gather facts

### DIFF
--- a/archive.yml
+++ b/archive.yml
@@ -1,16 +1,5 @@
 ---
 
-- name: collect info on frontend hosts
-  hosts:
-    - lead_frontend
-    - frontend
-    - legacy_frontend
-  # NOOP only to acquire IP address information about connected hosts,
-  # needed for rsyslog config
-  tasks: []
-  tags:
-    - collect-info
-
 - name: install archive
   hosts: archive
   roles:

--- a/broker.yml
+++ b/broker.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: collect info on broker connected hosts
-  hosts: broker_connected
-  # NOOP only to acquire IP address information about connected hosts.
-  tasks: []
-
 - name: install rabbitmq
   hosts: broker
   roles:

--- a/database.yml
+++ b/database.yml
@@ -1,13 +1,6 @@
 ---
 # Playbook for managing the database and replicant.
 
-- name: collect info on database connected hosts
-  hosts:
-    - db_connected
-    - replicant
-  # NOOP only to acquire IP address information about connected hosts.
-  tasks: []
-
 - name: install postgres database
   hosts:
     - database

--- a/frontend.yml
+++ b/frontend.yml
@@ -1,16 +1,6 @@
 ---
 # Install frontend components
 
-- name: collect info on legacy_frontend host(s)
-  hosts:
-    - legacy_frontend
-    - archive
-    - publishing
-  # NOOP only to acquire IP address information about connected hosts.
-  tasks: []
-  tags:
-    - collect-info
-
 - name: install frontend
   hosts:
     - frontend

--- a/lead_frontend.yml
+++ b/lead_frontend.yml
@@ -1,14 +1,6 @@
 ---
 # Playbook for installing the HAProxy service for initial request consumption.
 
-- name: collect info on connected hosts
-  hosts:
-    - frontend
-    - legacy_frontend
-    - zope
-  # NOOP only to acquire IP address information about hosts.
-  tasks: []
-
 - name: generate a self-signed certificate
   hosts:
     - lead_frontend

--- a/legacy_frontend.yml
+++ b/legacy_frontend.yml
@@ -1,12 +1,6 @@
 ---
 # Playbook for installing the haproxy service tier
 
-- name: collect info on zclients hosts
-  hosts:
-    - zclient
-  # NOOP only to acquire IP address information about hosts.
-  tasks: []
-
 - name: zcluster
   hosts:
     - legacy_frontend

--- a/nfs.yml
+++ b/nfs.yml
@@ -4,11 +4,6 @@
 # Note: Changes to the NFS server do not automatically cause the service
 # to restart or reload.
 
-- name: collect info on nfs connected hosts
-  hosts: nfs_connected
-  # NOOP only to acquire IP address information about connected hosts.
-  tasks: []
-
 - name: install nfs server
   hosts: nfs
   become: yes
@@ -18,6 +13,12 @@
       apt:
         name: nfs-kernel-server
         state: present
+    - name: gather facts from nfs connected
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: yes
+      with_items:
+        - "{{ groups.nfs_connected }}"
     - name: configure nfs server
       template:
         src: etc/exports

--- a/publishing.yml
+++ b/publishing.yml
@@ -1,16 +1,5 @@
 ---
 
-- name: collect info on frontend hosts
-  hosts:
-    - lead_frontend
-    - frontend
-    - legacy_frontend
-  # NOOP only to acquire IP address information about connected hosts,
-  # needed for rsyslog config
-  tasks: []
-  tags:
-    - collect-info
-
 - name: install publishing
   hosts: publishing
   roles:

--- a/publishing_worker.yml
+++ b/publishing_worker.yml
@@ -1,10 +1,5 @@
 ---
 
-- name: collect info on broker connected hosts
-  hosts: broker
-  # NOOP only to acquire IP address information about connected hosts.
-  tasks: []
-
 - name: install publishing celery worker
   hosts: publishing_worker
   roles:

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -165,6 +165,15 @@
 # Rsyslog Configuration
 # +++
 
+- name: gather facts from frontend hosts
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.lead_frontend }}"
+    - "{{ groups.frontend }}"
+    - "{{ groups.legacy_frontend }}"
+
 - name: connect archive log to rsyslog
   become: yes
   template:

--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -1,6 +1,15 @@
 ---
 # Configure HAProxy
 
+- name: gather facts from zope and frontend servers
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.zope }}"
+    - "{{ groups.lead_frontend }}"
+    - "{{ groups.frontend }}"
+
 - name: configure lead load balancer
   become: yes
   blockinfile:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -29,6 +29,14 @@
 # Configure
 # +++
 
+- name: gather facts from db_connected
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.db_connected }}"
+    - "{{ groups.replicant }}"
+
 - name: configure postgres role connection trust
   become: yes
   template:

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -46,6 +46,15 @@
 # Rsyslog Configuration
 # +++
 
+- name: gather facts from frontend
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.lead_frontend }}"
+    - "{{ groups.frontend }}"
+    - "{{ groups.legacy_frontend }}"
+
 - name: connect publishing log to rsyslog
   become: yes
   template:

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -138,6 +138,13 @@
   notify:
     - initialize repository database
 
+- name: gather facts from broker
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.broker }}"
+
 - name: render configuration
   become: yes
   template:

--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -30,6 +30,15 @@
 # Configure
 # +++
 
+- name: gather facts from legacy frontend, archive and publishing
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.legacy_frontend }}"
+    - "{{ groups.archive }}"
+    - "{{ groups.publishing }}"
+
 - name: configure varnish logic
   become: yes
   template:

--- a/roles/zclient_load_balancer/tasks/main.yml
+++ b/roles/zclient_load_balancer/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
 # Configure HAProxy
 
+- name: gather facts from zclients
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.zclient }}"
+
 - name: configure haproxy zcluster
   become: yes
   blockinfile:


### PR DESCRIPTION
We used `tasks: []` to gather facts (mostly ip addresses) from other
servers.  There is a different way of doing this in ansible 2 called
delegated facts.

http://docs.ansible.com/ansible/latest/playbooks_delegation.html#delegated-facts

This allows us to gather facts from other hosts that we need for
configuration.