### PR TITLE
Allow cache purges from any connected hosts

### DIFF
--- a/environments/content01/inventory
+++ b/environments/content01/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/content02/inventory
+++ b/environments/content02/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/content03/inventory
+++ b/environments/content03/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/content04/inventory
+++ b/environments/content04/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/content05/inventory
+++ b/environments/content05/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/des/inventory
+++ b/environments/des/inventory
@@ -91,3 +91,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/dev/inventory
+++ b/environments/dev/inventory
@@ -93,3 +93,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/legacy-staging/inventory
+++ b/environments/legacy-staging/inventory
@@ -44,3 +44,7 @@ archive
 publishing
 authoring
 zclient
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/local-accounts-vm/inventory
+++ b/environments/local-accounts-vm/inventory
@@ -10,3 +10,7 @@ accounts.local.openstax.org
 [accounts:vars]
 email_api_key=instant-ramen
 root_prefix=
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/prod/inventory
+++ b/environments/prod/inventory
@@ -115,3 +115,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/qa/inventory
+++ b/environments/qa/inventory
@@ -78,3 +78,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -115,3 +115,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/tea/inventory
+++ b/environments/tea/inventory
@@ -81,3 +81,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -81,3 +81,7 @@ pdf_gen
 zeo
 zclient
 pdf_gen
+
+[varnish_purge_allowed:children]
+zope
+publishing

--- a/roles/varnish/tasks/main.yml
+++ b/roles/varnish/tasks/main.yml
@@ -30,12 +30,12 @@
 # Configure
 # +++
 
-- name: gather facts from legacy frontend, archive and publishing
+- name: gather facts from hosts allowed to purge varnish cache
   setup:
   delegate_to: "{{ item }}"
   delegate_facts: yes
   with_items:
-    - "{{ groups.all }}"
+    - "{{ groups.varnish_purge_allowed }}"
 
 - name: configure varnish logic
   become: yes

--- a/update_versions.yml
+++ b/update_versions.yml
@@ -68,7 +68,7 @@
       args:
         executable: /bin/sh
     - name: purge cached version.txt
-      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/version.txt'"
+      command: "curl -X PURGE 'http://{{ frontend_domain }}/version.txt'"
 
 - name: update python-version.txt
   hosts: frontend
@@ -93,7 +93,7 @@
       args:
         executable: /bin/sh
     - name: purge cached python-version.txt
-      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/python-version.txt'"
+      command: "curl -X PURGE 'http://{{ frontend_domain }}/python-version.txt'"
 
 - name: update history.txt
   hosts: frontend
@@ -113,4 +113,4 @@
       args:
         executable: /bin/sh
     - name: purge cached history.txt
-      command: "curl -X PURGE 'http://{{ frontend_domain }}:{{ varnish_port }}/history.txt'"
+      command: "curl -X PURGE 'http://{{ frontend_domain }}/history.txt'"


### PR DESCRIPTION
Include all the IP addresses from all the hosts except the frontend ones
(the ones with varnish) in the acl purge list.

If the frontend hosts are included, then any host can issue a PURGE
request which may not be what we want.

Close #129