### PR TITLE
Fix frontend.yml not able to find authoring IP address

### DIFF
--- a/roles/webview/tasks/webview.yml
+++ b/roles/webview/tasks/webview.yml
@@ -45,6 +45,13 @@
 # Configure
 # +++
 
+- name: gather facts from authoring
+  setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  with_items:
+    - "{{ groups.authoring }}"
+
 - name: configure webview settings.js
   become: yes
   template:


### PR DESCRIPTION
If authoring is not on any of the frontend hosts, when running
frontend.yml, ansible returns this error message:

```
TASK [webview : configure the webview nginx site] ****************************************************************************************************************************
fatal: [local.cnx.org]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'ansible_default_ipv4'"}
```

Fix this by gathering facts from authoring before this step in
webview.yml.