### PR TITLE
Enable sysstat on all servers

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -67,6 +67,10 @@
     - iptables
     - firewall
 
+- import_playbook: sysstat.yml
+  tags:
+    - sysstat
+
 - import_playbook: update_versions.yml
 
 - name: "notify #cnx-stream of the deployment (end)"

--- a/roles/sysstat/files/etc/default/sysstat
+++ b/roles/sysstat/files/etc/default/sysstat
@@ -1,0 +1,9 @@
+#
+# Default settings for /etc/init.d/sysstat, /etc/cron.d/sysstat
+# and /etc/cron.daily/sysstat files
+#
+
+# Should sadc collect system activity informations? Valid values
+# are "true" and "false". Please do not put other values, they
+# will be overwritten by debconf!
+ENABLED="true"

--- a/roles/sysstat/handlers/main.yml
+++ b/roles/sysstat/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart sysstat
+  become: yes
+  service:
+    name: sysstat
+    state: restarted

--- a/roles/sysstat/tasks/main.yml
+++ b/roles/sysstat/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: apt install sysstat
+  become: yes
+  apt:
+    name: sysstat
+    state: installed
+
+- name: enable sysstat
+  become: yes
+  copy:
+    src: etc/default/sysstat
+    dest: /etc/default/sysstat
+    mode: 0644
+  notify:
+    - restart sysstat

--- a/sysstat.yml
+++ b/sysstat.yml
@@ -1,0 +1,7 @@
+---
+- name: set up sysstat
+  hosts: all
+  roles:
+    - role: sysstat
+  tags:
+    - sysstat


### PR DESCRIPTION
Install sysstat and enable it on all servers so we can collect stats
from the servers and help debug performance problems.

Close #437