### PR TITLE
Always restart archive and publishing

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -96,6 +96,9 @@
   pip:
     requirements: "/var/lib/cnx/archive-requirements.txt"
     virtualenv: "/var/cnx/venvs/archive"
+
+- name: restart archive
+  command: "/bin/true"
   notify:
     - restart archive
 

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -100,6 +100,9 @@
   pip:
     requirements: "/var/lib/cnx/publishing-requirements.txt"
     virtualenv: "/var/cnx/venvs/publishing"
+
+- name: restart publishing
+  command: "/bin/true"
   notify:
     - list supervisor applications
     - restart publishing


### PR DESCRIPTION
The current logic to restart archive and publishing when code or
configuration has changed is not wrong.  The problem is ansible doesn't
restart archive and publishing immediately when we notify the handlers,
it only does it after all the tasks in the same playbook are finished.
If any task fails in the middle, the services are not restarted.  The
next time we run cnx-deploy, it'll see that the code and configuration
haven't changed and so does not try to restart the services.  This
happened so many times that may be we will just always restart the
services.