### PR TITLE
(DISCUSS) Change haproxy to use leastconn for cnx.org varnish

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -43,7 +43,7 @@
 
       # Load balancing the frontend grouping
       backend nodes
-        balance uri
+        balance leastconn
         option httpchk GET /ping HTTP/1.1\r\nHOST:\ {{ frontend_domain }}
         option forwardfor
 


### PR DESCRIPTION
We were using uri hashing for varnish before.  The reason is we have
multiple varnish instances, if we use uri hashing, there is a higher
chance of getting a cache hit.

I did some experiment with different load balancing algorithms.  I set
up 2 varnish instances and 2 archive instances, one has `time.sleep(5)`
added to it to show what happens if archive is being slow.  I have 500
archive urls and 10 wget processes that fetch 50 urls each.

1. Using uri hashing:

   Fetching all the urls with no cache took 57 seconds.  The normal
   archive served 457 urls and the slow one served 42.

   Fetching all the urls again took 6 seconds.  All the subsequent
   fetches took less than 2 seconds.

2. Using leastconn:

   Fetching all the urls with no cache took 53 seconds.  The normal
   archive served 459 urls and the slow one served 40.

   Fetching all the urls the second time took 51 seconds, the third time
   45 seconds, the fourth time 50 seconds.

3. Using roundrobin with maxconn 4:

   Fetching all the urls with no cache took 42 seconds.  The normal
   archive served 470 urls and the slow one served 30.

   Fetching all the urls the second time took 51 seconds, the third time
   1 minute 5 seconds, the fourth time 25 seconds.

Archive instances being slow may not be the problem we saw on
production.  Perhaps we were having problems with varnish instead.  In
that case, using leastconn or roundrobin might give us better
performance overall.