### PR TITLE
Unified file in collections

### DIFF
--- a/tasks/set_up_rhaptos_print_host.yml
+++ b/tasks/set_up_rhaptos_print_host.yml
@@ -1,6 +1,0 @@
----
-
-- name: set up rhaptos print host
-  shell: "echo -c \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
-  args:
-    chdir: "/var/lib/cnx/cnx-buildout"

--- a/tasks/set_up_rhaptos_site.yml
+++ b/tasks/set_up_rhaptos_site.yml
@@ -4,3 +4,8 @@
   shell: "./bin/instance run scripts/set_up_localfs_for_pdfs.py {% for item in archive_exports_directories|default(default_archive_exports_directories) %}pdfs{{ loop.index }}:/var/www/{{ item }} {% endfor %}"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
+
+- name: set up rhaptos print host
+  shell: "echo -c \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
+  args:
+    chdir: "/var/lib/cnx/cnx-buildout"

--- a/tasks/set_up_rhaptos_site.yml
+++ b/tasks/set_up_rhaptos_site.yml
@@ -9,3 +9,8 @@
   shell: "echo -c \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
+
+- name: set up collections allowed content types
+  shell: "echo -c \"app.plone.portal_types.Collection.allowed_content_types += ('UnifiedFile',); import transaction; transaction.commit()\" | ./bin/instance debug"
+  args:
+    chdir: "/var/lib/cnx/cnx-buildout"

--- a/zope.yml
+++ b/zope.yml
@@ -16,9 +16,7 @@
   tasks:
     - import_tasks: tasks/create_rhaptos_site.yml
       run_once: yes
-    - import_tasks: tasks/set_up_localfs_folders.yml
-      run_once: yes
-    - import_tasks: tasks/set_up_rhaptos_print_host.yml
+    - import_tasks: tasks/set_up_rhaptos_site.yml
       run_once: yes
   tags:
     - zope


### PR DESCRIPTION
- Include UnifiedFile in Collection allowed_content_types

  In order to add a ruleset.css recipe to a collection, `UnifiedFile`
  needs to be added as a allowed content type in the ZMI.
  
  I was looking into doing this in Products.RhaptosCollection
  /profiles/default/types/Collection.xml where the type is
  defined, but running buildout doesn't seem to pick the changes up.  May
  be we're not reinstalling the products every time we run buildout.
  
  Close #439

- Combine rhaptos site set up tasks into one file

  Merge `tasks/set_up_rhaptos_print_host.yml` and
  `tasks/set_up_localfs_folders.yml` into
  `tasks/set_up_rhaptos_print_host.yml`.  There is only one task in each
  of the task files so can just put them in the same file.

