### PR TITLE
Remove hourly archive restart cron job

### DIFF
--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -160,6 +160,7 @@
   with_items:
     - cron.daily
     - cron.weekly
+    - cron.hourly
 
 # +++
 # Rsyslog Configuration


### PR DESCRIPTION
We removed daily and weekly archive restart cron jobs but we have hourly
cron jobs on production, so need to remove that too.