### PR TITLE
Use "command" with pgrep in run_deferred_migrations.yml

### DIFF
--- a/run_deferred_migrations.yml
+++ b/run_deferred_migrations.yml
@@ -4,7 +4,7 @@
   hosts: publishing
   tasks:
     - name: check if deferred migrations are running
-      shell: "pgrep -f run-deferred"
+      command: "pgrep -f run-deferred"
       register: deferred_migrations
       ignore_errors: yes
 


### PR DESCRIPTION
`shell: pgrep -f run-deferred` was working in ansible v2.4.0.0 but
didn't work on bastion2 which runs ansible v2.4.2.0.

Perhaps the reason is when using `shell:`, ansible v2.4.2.0 is doing:

```
/bin/sh -c 'pgrep -f run-deferred'
```

which always return a different PID, probably matching against itself.

This is fixed by using `command: pgrep -f run-deferred`.