### PR TITLE
Move cnx logs from /var/log/syslog to /var/log/cnx.log

### DIFF
--- a/roles/archive/meta/main.yml
+++ b/roles/archive/meta/main.yml
@@ -6,3 +6,4 @@ dependencies:
   - memcached
   - supervisord
   - rsyslog
+  - logrotate

--- a/roles/archive/templates/etc/rsyslog.d/10-archive.conf
+++ b/roles/archive/templates/etc/rsyslog.d/10-archive.conf
@@ -5,4 +5,6 @@ input(type="imfile"
       Tag="cnxarchive"
       Severity="info")
 
-if $syslogtag == "cnxarchive" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~
+if $syslogtag == "cnxarchive" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then stop
+if $syslogtag == "cnxarchive" then /var/log/cnx.log
+& stop

--- a/roles/authoring/meta/main.yml
+++ b/roles/authoring/meta/main.yml
@@ -6,3 +6,4 @@ dependencies:
   - memcached
   - supervisord
   - rsyslog
+  - logrotate

--- a/roles/authoring/templates/etc/rsyslog.d/10-authoring.conf
+++ b/roles/authoring/templates/etc/rsyslog.d/10-authoring.conf
@@ -4,3 +4,6 @@ input(type="imfile"
       File="/var/log/supervisor/authoring*.log"
       Tag="cnxauthoring"
       Severity="info")
+
+if $syslogtag == "cnxauthoring" then /var/log/cnx.log
+& stop

--- a/roles/channel_processing/meta/main.yml
+++ b/roles/channel_processing/meta/main.yml
@@ -3,3 +3,4 @@
 dependencies:
   - publishing_common
   - rsyslog
+  - logrotate

--- a/roles/channel_processing/templates/etc/rsyslog.d/10-channel-processing.conf
+++ b/roles/channel_processing/templates/etc/rsyslog.d/10-channel-processing.conf
@@ -4,3 +4,6 @@ input(type="imfile"
       File="/var/log/supervisor/channel_processing*.log"
       Tag="channel_processing"
       Severity="info")
+
+if $syslogtag == "channel_processing" then /var/log/cnx.log
+& stop

--- a/roles/logrotate/files/etc/logrotate.d/cnx
+++ b/roles/logrotate/files/etc/logrotate.d/cnx
@@ -1,0 +1,12 @@
+/var/log/cnx.log
+{
+    rotate 4
+    weekly
+    missingok
+    notifempty
+    compress
+    delaycompress
+    postrotate
+        invoke-rc.d rsyslog rotate > /dev/null
+    endscript
+}

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: logrotate cnx.log
+  become: yes
+  copy:
+    src: etc/logrotate.d/cnx
+    dest: /etc/logrotate.d/cnx
+    mode: 0644
+  tags: logrotate-conf

--- a/roles/publishing/meta/main.yml
+++ b/roles/publishing/meta/main.yml
@@ -3,3 +3,4 @@
 dependencies:
   - publishing_common
   - rsyslog
+  - logrotate

--- a/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
+++ b/roles/publishing/templates/etc/rsyslog.d/10-publishing.conf
@@ -5,4 +5,6 @@ input(type="imfile"
       Tag="cnxpublishing"
       Severity="info")
 
-if $syslogtag == "cnxpublishing" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then ~
+if $syslogtag == "cnxpublishing" and ({% for host in groups.lead_frontend + groups.frontend + groups.legacy_frontend %}$msg startswith "{{ hostvars[host].ansible_default_ipv4.address }}"{% if not loop.last %} or {% endif %}{% endfor %}) then stop
+if $syslogtag == "cnxpublishing" then /var/log/cnx.log
+& stop

--- a/roles/publishing_worker/meta/main.yml
+++ b/roles/publishing_worker/meta/main.yml
@@ -3,3 +3,4 @@
 dependencies:
   - publishing_common
   - rsyslog
+  - logrotate

--- a/roles/publishing_worker/templates/etc/rsyslog.d/10-publishing-worker.conf
+++ b/roles/publishing_worker/templates/etc/rsyslog.d/10-publishing-worker.conf
@@ -4,3 +4,6 @@ input(type="imfile"
       File="/var/log/supervisor/publishing_celery_worker*.log"
       Tag="cnxpublishing_worker"
       Severity="info")
+
+if $syslogtag == "cnxpublishing_worker" then /var/log/cnx.log
+& stop


### PR DESCRIPTION
- Rotate /var/log/cnx.log every week

  /var/log/cnx.log has what we send to graylog, to keep the files from
  growing too big, we are rotating the files every week.  The cnx
  logrotate config file is based on the rsyslog logrotate config file.

- Move cnx logs from /var/log/syslog to /var/log/cnx.log

  There is no need to have the cnx logs to be in /var/log/syslog to get
  them forwarded to graylog.  It is good to have /var/log/cnx.log which
  has everything that should be in graylog.
  
  Close #458

