### PR TITLE
Update copy database playbooks

### DIFF
--- a/copy_database.yml
+++ b/copy_database.yml
@@ -51,6 +51,8 @@
       vars:
         db_owner: "postgres"
     - name: pipe database in
+      become: yes
+      become_user: postgres
       shell: "set -o pipefail && pg_dump -U postgres -h {{ source_db_host }} -p {{ source_db_port }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
       args:
         executable: "/bin/bash"

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -9,6 +9,10 @@
       prompt: "Where is the database hosted?"
       private: no
       default: prod09.cnx.org
+    - name: "source_db_port"
+      prompt: "What port is the database listening on?"
+      private: no
+      default: 5432
     - name: "db_name"
       prompt: "What database are we pull from to dump onto this machine?"
       private: no
@@ -16,6 +20,7 @@
   tasks:
     - set_fact:
         source_db_host: "{{ source_db_host }}"
+        source_db_port: "{{ source_db_port }}"
         source_db_name: "{{ db_name }}"
         db_name: "{{ db_name }}_new"
 
@@ -46,7 +51,7 @@
       vars:
         db_owner: "postgres"
     - name: pipe database in
-      shell: "set -o pipefail && pg_dump -U postgres -h {{ source_db_host }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
+      shell: "set -o pipefail && pg_dump -U postgres -h {{ source_db_host }} -p {{ source_db_port }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
       args:
         executable: "/bin/bash"
     - name: migrate database

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -56,6 +56,38 @@
       shell: "set -o pipefail && pg_dump -U postgres -h {{ source_db_host }} -p {{ source_db_port }} {{ source_db_name }} | psql -U postgres {{ db_name }} -f -"
       args:
         executable: "/bin/bash"
+    - name: change ownership of database
+      become: yes
+      become_user: postgres
+      shell: "psql -U postgres -d {{ db_name }} -c 'ALTER DATABASE {{ db_name }} OWNER TO {{ archive_db_user }};'"
+    - name: remove venv schema
+      become: yes
+      become_user: postgres
+      shell: "psql -U postgres -d {{ db_name }} -c 'DROP SCHEMA IF EXISTS venv CASCADE;'"
+
+- name: set up venv and migrate database
+  hosts: publishing
+  tasks:
+    - name: rerun cnx-db venv
+      become: yes
+      become_user: www-data
+      environment:
+        DB_URL: "postgresql://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ db_name }}"
+        DB_SUPER_URL: "postgresql://postgres:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ db_name }}"
+      command: "/var/cnx/venvs/publishing/bin/cnx-db venv"
+    - name: change ownership of venv schema
+      become: yes
+      become_user: postgres
+      delegate_to: "{{ groups.database|first }}"
+      command: "psql -U postgres -d {{ db_name }} -c 'ALTER SCHEMA venv OWNER TO {{ archive_db_user }};'"
     - name: migrate database
-      debug:
-        msg: "Now run the database migration if needed: /var/cnx/venvs/{{ venv_environment|default('publishing') }}/bin/dbmigrator --db-connection-string \"{{ db_connection_string }}\" ... migrate"
+      become: yes
+      become_user: www-data
+      environment:
+        # If PGHOST is not set, psql tries to look for cluster "main" which doesn't
+        # work:
+        #     $ psql -U postgres -l
+        #     Error: Invalid data directory
+        # This appears to be a problem after a postgresql-common update
+        PGHOST: "{{ archive_db_host }}"
+      command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-db migrate"

--- a/run_deferred_migrations.yml
+++ b/run_deferred_migrations.yml
@@ -23,6 +23,13 @@
       shell: "nohup /var/cnx/venvs/publishing/bin/dbmigrator --context=cnx-db --config /etc/cnx/archive/app.ini migrate --run-deferred  > /tmp/deferred-migrations.out 2>/tmp/deferred-migrations.err &"
       args:
         executable: "/bin/bash"
+      environment:
+        # If PGHOST is not set, psql tries to look for cluster "main" which doesn't
+        # work:
+        #     $ psql -U postgres -l
+        #     Error: Invalid data directory
+        # This appears to be a problem after a postgresql-common update
+        PGHOST: "{{ archive_db_host }}"
       become: yes
       become_user: "{{ venvs_owner|default('www-data') }}"
       run_once: yes

--- a/swap_database.yml
+++ b/swap_database.yml
@@ -88,6 +88,8 @@
   hosts: database
   tasks:
     - name: rename via pgsql
+      become: yes
+      become_user: postgres
       shell: |
         psql -v ON_ERROR_STOP=1 --username postgres <<-" EOSQL"
         DROP DATABASE IF EXISTS {{ dest_db_name }};

--- a/swap_database.yml
+++ b/swap_database.yml
@@ -48,6 +48,22 @@
         name: "post_publication:"
         state: stopped
 
+- name: stop publishing celery workers
+  hosts: publishing
+  tasks:
+    - become: yes
+      supervisorctl:
+        name: "publishing_worker:"
+        state: stopped
+
+- name: stop channel processing
+  hosts: publishing
+  tasks:
+    - become: yes
+      supervisorctl:
+        name: "channel_processing"
+        state: stopped
+
 - name: stop zclients
   hosts:
     - zclient
@@ -126,6 +142,22 @@
       when: post_publication_bin.stat.exists
       supervisorctl:
         name: "post_publication:"
+        state: started
+
+- name: start publishing celery workers
+  hosts: publishing
+  tasks:
+    - become: yes
+      supervisorctl:
+        name: "publishing_worker:"
+        state: started
+
+- name: start channel processing
+  hosts: publishing
+  tasks:
+    - become: yes
+      supervisorctl:
+        name: "channel_processing"
         state: started
 
 - name: start zclients


### PR DESCRIPTION
- Rerun cnx-db venv and migrate database in copy_database.yml

  The venv in the copied database may not work on the new host so we need
  to rerun cnx-db venv to set it up correctly.  Also migrate the copied
  database so it can work with the existing code.

- Run psql commands with PGHOST or as postgres

  On fresh ubuntu 16.04 servers (e.g. katalyst01), we have problems
  running psql commands as non-root or non-postgres users:
  
  ```
  karen@katalyst01:~$ psql -U postgres
  Error: Invalid data directory
  ```
  
  There are different ways of getting this to work:
  
  ```
  karen@katalyst01:~$ sudo -u postgres psql -U postgres
  psql (9.4.15)
  Type "help" for help.
  postgres=# \q
  ```
  
  ```
  karen@katalyst01:~$ PGHOST=localhost psql -U postgres
  psql (9.4.15)
  SSL connection (protocol: TLSv1.2, cipher: ECDHE-RSA-AES256-GCM-SHA384,
  bits: 256, compression: off)
  Type "help" for help.
  
  postgres=#
  ```
  
  For psql commands that don't require a special user, we use `postgres`
  as the user and for commands that are already running as a different
  user, we use `PGHOST` method.

- Stop publishing workers before swapping database

  There were still services connected to the postgres database when
  attempting to swap the database.  We needed to stop publishing celery
  workers and channel processing before swapping the database.

- Add source_db_host to copy_database.yml

  Sometimes the destination host does not have permission to access the
  source database.  If this is a one off copy, we may not want to add the
  destination host IP to the source postgres config.  In that case, we can
  set up a ssh tunnel to forward the source postgres port to the
  destination server, for example:
  
  ```
  source-server:~$ ssh -R 5433:localhost:5432 destination-server
  ```
  
  In this case, when we copy the database, we can use `localhost` and
  `5433` as the source host and port.
  
  There was no way to specify the source port in copy_database.yml.
