### PR TITLE
Add backup role in database.yml

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -54,3 +54,12 @@
     - database
     - replication
     - be
+
+- name: set up database backup
+  hosts:
+    - backup
+  roles:
+    - backup
+  tags:
+    - database
+    - backup

--- a/environments/content01/inventory
+++ b/environments/content01/inventory
@@ -50,6 +50,8 @@ content01
 [pdf_gen:children]
 content01
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/content02/inventory
+++ b/environments/content02/inventory
@@ -50,6 +50,8 @@ content02
 [pdf_gen:children]
 content02
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/content03/inventory
+++ b/environments/content03/inventory
@@ -50,6 +50,8 @@ content03
 [pdf_gen:children]
 content03
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/content04/inventory
+++ b/environments/content04/inventory
@@ -50,6 +50,8 @@ content04
 [pdf_gen:children]
 content04
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/content05/inventory
+++ b/environments/content05/inventory
@@ -50,6 +50,8 @@ content05
 [pdf_gen:children]
 content05
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/des/inventory
+++ b/environments/des/inventory
@@ -65,6 +65,8 @@ des00
 [pdf_gen:children]
 des00
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -79,6 +81,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 legacy_frontend

--- a/environments/dev/inventory
+++ b/environments/dev/inventory
@@ -67,6 +67,8 @@ dev02
 [pdf_gen:children]
 dev03
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -82,6 +84,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 legacy_frontend

--- a/environments/devb/inventory
+++ b/environments/devb/inventory
@@ -50,6 +50,8 @@ devb
 [pdf_gen:children]
 devb
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/katalyst01/inventory
+++ b/environments/katalyst01/inventory
@@ -50,6 +50,8 @@ katalyst01
 [pdf_gen:children]
 katalyst01
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/legacy-staging/inventory
+++ b/environments/legacy-staging/inventory
@@ -37,6 +37,8 @@ legacy_staging
 [pdf_gen:children]
 legacy_staging
 
+[backup:children]
+
 # Groups of groups
 
 [db_connected:children]
@@ -44,6 +46,7 @@ archive
 publishing
 authoring
 zclient
+backup
 
 [varnish_purge_allowed:children]
 zope

--- a/environments/prod/host_vars/backup2.cnx.org
+++ b/environments/prod/host_vars/backup2.cnx.org
@@ -1,0 +1,4 @@
+---
+slim_dumps: yes
+# Point at the replicant:
+archive_db_host: prod10.cnx.org

--- a/environments/prod/inventory
+++ b/environments/prod/inventory
@@ -37,6 +37,9 @@ prod-files00.cnx.org
 [prod_files01]
 prod-files01.cnx.org
 
+[backup2]
+backup2.cnx.org
+
 # Grouped Hosts
 
 [nfs:children]
@@ -87,6 +90,9 @@ prod05
 [pdf_gen:children]
 prod06
 
+[backup:children]
+backup2
+
 # Groups of groups
 
 [broker_connected:children]
@@ -102,6 +108,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/qa/inventory
+++ b/environments/qa/inventory
@@ -50,6 +50,8 @@ qa00
 [pdf_gen:children]
 qa00
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -65,6 +67,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -37,6 +37,9 @@ staging-files00.cnx.org
 [staging_files01]
 staging-files01.cnx.org
 
+[backup2]
+backup2.cnx.org
+
 # Grouped Hosts
 
 [nfs:children]
@@ -87,6 +90,9 @@ staging05
 [pdf_gen:children]
 staging06
 
+[backup:children]
+backup2
+
 # Groups of groups
 
 [broker_connected:children]
@@ -102,6 +108,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/environments/tea/inventory
+++ b/environments/tea/inventory
@@ -55,6 +55,8 @@ tea00
 [pdf_gen:children]
 tea01
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -70,6 +72,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 legacy_frontend

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -52,6 +52,8 @@ zope.local.cnx.org
 [pdf_gen:children]
 zope.local.cnx.org
 
+[backup:children]
+
 # Groups of groups
 
 [broker_connected:children]
@@ -67,6 +69,7 @@ publishing_worker
 authoring
 zclient
 pdf_gen
+backup
 
 [nfs_connected:children]
 archive

--- a/roles/backup/meta/main.yml
+++ b/roles/backup/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - postgres

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: set up weekly backup
+  become: yes
+  template:
+    src: etc/cron.weekly/cnx-backup
+    dest: /etc/cron.weekly/cnx-backup
+    mode: 0755
+
+- name: set up slim dumps
+  become: yes
+  when: slim_dumps|default(False)
+  template:
+    src: etc/cron.weekly/cnx-slim-dump
+    dest: /etc/cron.weekly/cnx-slim-dump
+    mode: 0755

--- a/roles/backup/templates/etc/cron.weekly/cnx-backup
+++ b/roles/backup/templates/etc/cron.weekly/cnx-backup
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Create a cnx database dump for backup
+
+DB_DUMP_BASE_NAME="/var/backups/cnx_dump"
+DB_DUMP_FILENAME=$DB_DUMP_BASE_NAME.$(date +%Y-%m-%d).sql.gz
+
+ARCHIVE_DB_HOST={{ archive_db_host }}
+ARCHIVE_DB_PORT={{ archive_db_port }}
+ARCHIVE_DB_USER={{ archive_db_user }}
+ARCHIVE_DB_NAME={{ archive_db_name }}
+
+# Install clean up code
+function cleanup {
+    bname=$(basename $DB_DUMP_BASE_NAME)
+    ls -1 -r $(dirname $DB_DUMP_BASE_NAME)/${bname/.*/}* | sed -n '4,$ p' | xargs rm -f
+}
+trap cleanup EXIT
+
+pg_dump -h "$ARCHIVE_DB_HOST" -p "$ARCHIVE_DB_PORT" -U "$ARCHIVE_DB_USER" \
+    "$ARCHIVE_DB_NAME" | gzip >"$DB_DUMP_FILENAME"

--- a/roles/backup/templates/etc/cron.weekly/cnx-slim-dump
+++ b/roles/backup/templates/etc/cron.weekly/cnx-slim-dump
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Create a slim dump of the cnx production database so developers can use it
+# for development and testing
+
+# 0. Make sure this server can access the production database (with pg_dump or
+#    ssh)
+
+# Target databases settings
+SLIM_DUMP_DB_NAME=cnx_slim_dump
+SLIM_DUMP_FILENAME="/var/backups/$SLIM_DUMP_DB_NAME.$(date +%Y-%m-%d).sql.gz"
+
+# Source databases settings
+ARCHIVE_DB_HOST={{ archive_db_host }}
+ARCHIVE_DB_PORT={{ archive_db_port }}
+ARCHIVE_DB_USER={{ archive_db_user }}
+ARCHIVE_DB_NAME={{ archive_db_name }}
+
+# Only set SSH_USER if pg_dump cannot access the production database
+SSH_USER=
+
+# Install clean up code
+function cleanup {
+    # Only keep 3 copies of slim dump
+    bname=$(basename $SLIM_DUMP_FILENAME)
+    ls -1 -r $(dirname $SLIM_DUMP_FILENAME)/${bname/.*/}* | sed -n '4,$ p' | xargs rm -f
+    psql -U postgres -c "DROP DATABASE IF EXISTS $SLIM_DUMP_DB_NAME;"
+}
+trap cleanup EXIT
+
+# 1. Create a temporary database for the slim dump
+psql -U postgres <<EOF
+DROP DATABASE IF EXISTS $SLIM_DUMP_DB_NAME;
+CREATE DATABASE $SLIM_DUMP_DB_NAME;
+EOF
+
+# 2. Copy the production database (or a backup of)
+if [[ -z "$SSH_USER" ]]
+then
+    pg_dump -h "$ARCHIVE_DB_HOST" -p "$ARCHIVE_DB_PORT" -U "$ARCHIVE_DB_USER" \
+        "$ARCHIVE_DB_NAME" | psql -U postgres $SLIM_DUMP_DB_NAME
+else
+    ssh -l $SSH_USER $ARCHIVE_DB_HOST pg_dump -U "$ARCHIVE_DB_USER" \
+        "$ARCHIVE_DB_NAME" | psql -U postgres $SLIM_DUMP_DB_NAME
+fi
+
+# 3. Replace the resource files in cnx_slim_dump with dummy files except
+#    index.cnxml, index.cnxml.html, index_auto_generated.cnxml, ruleset.css,
+#    featured-cover.png
+psql -U postgres $SLIM_DUMP_DB_NAME <<EOF
+ALTER TABLE files DISABLE TRIGGER USER;
+
+UPDATE files SET file = 'dummy'
+    WHERE NOT EXISTS (
+        SELECT 1 FROM module_files
+        WHERE filename IN ('index.cnxml', 'index.cnxml.html',
+                           'index_auto_generated.cnxml',
+                           'ruleset.css', 'featured-cover.png',
+                           'collection.xml')
+          AND files.fileid = module_files.fileid);
+
+-- dummy 1x1.png file from https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png
+UPDATE files SET file = '\\x89504e470d0a1a0a0000000d494844520000000100000001010300000025db56ca00000003504c5445000000a77a3dda0000000174524e530040e6d8660000000a4944415408d76360000000020001e221bc330000000049454e44ae426082'
+    WHERE EXISTS (
+        SELECT 1 FROM module_files
+        WHERE filename = 'featured-cover.png'
+          AND files.fileid = module_files.fileid);
+
+ALTER TABLE files ENABLE TRIGGER USER;
+EOF
+
+# 4. Create a database dump file for download
+pg_dump -U postgres $SLIM_DUMP_DB_NAME | gzip > $SLIM_DUMP_FILENAME


### PR DESCRIPTION
- Add backup host to environments

  Set up backup in different environments and set slim dumps to yes for
  production.

- Add backup role in database.yml

  The backup role creates a weekly cnx database dump and optionally a slim
  database dump.

