### PR TITLE
Update push_data.yml psql commands to use postgres user

### DIFF
--- a/push_data.yml
+++ b/push_data.yml
@@ -86,12 +86,18 @@
       become_user: postgres
       shell: "createdb -O {{ db_user }} {{ db_name }}"
     - name: load database without files
+      become: yes
+      become_user: postgres
       shell: "zcat /tmp/cnxarchive_dump/cnxarchive_dump_without_files.sql.gz | psql -U {{ db_user }} {{ db_name }} -f -"
 
     - name: load files table
+      become: yes
+      become_user: postgres
       shell: zcat '/tmp/cnxarchive_dump/cnxarchive_index_files.txt.gz' '/tmp/cnxarchive_dump/cnxarchive_other_files.txt.gz' | psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE files DISABLE TRIGGER USER; COPY files (fileid, md5, sha1, file, media_type) FROM STDIN; ALTER TABLE files ENABLE TRIGGER USER;"
 
     - name: load module files table
+      become: yes
+      become_user: postgres
       shell: zcat '/tmp/cnxarchive_dump/cnxarchive_index_module_files.txt' | psql -U {{ db_user }} {{ db_name }} -c "ALTER TABLE module_files DISABLE TRIGGER USER; COPY module_files (module_ident, fileid, filename) FROM STDIN; ALTER TABLE module_files ENABLE TRIGGER USER;"
     - name: remove dump files
       file:


### PR DESCRIPTION
With the latest ubuntu 16.04 server, when postgres command line tools
are used as users that are not root or postgres, we get this error:

```
karen@xenial-openstax-test:~$ psql -l
Error: Invalid data directory
```

To fix this in push_data.yml, we are going to run all the postgres
commands using the postgres user.