### PR TITLE
Download urw fonts from packages.cnx.org

### DIFF
--- a/roles/zope_common/tasks/pdf_gen_dependencies.yml
+++ b/roles/zope_common/tasks/pdf_gen_dependencies.yml
@@ -120,7 +120,7 @@
 - name: download urw fonts
   become: yes
   get_url:
-    url: "http://svn.ghostscript.com/ghostscript/trunk/ghostpdl/urwfonts/{{ item }}"
+    url: "https://packages.cnx.org/fonts/{{ item }}"
     dest: "/usr/share/fonts/urw"
   with_items:
     - URWPalladioL-Bold.ttf


### PR DESCRIPTION
http://svn.ghostscript.com/ does not exist anymore and while the fonts
are still on some older version of the git repository, it is probably
better to store the fonts on packages.cnx.org so we can be sure they are
always available.

Close #479