### PR TITLE
Add common db roles/users to the backup server for slim dump usage

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -60,6 +60,19 @@
     - backup
   roles:
     - backup
+  tasks:
+    - import_tasks: tasks/create_db_user.yml
+      vars:
+        db_user: "{{ archive_db_user }}"
+        db_password: "{{ archive_db_password }}"
+    - import_tasks: tasks/create_db_user.yml
+      vars:
+        db_user: "backups"
+        role_attr_flags: ""
+    - import_tasks: tasks/create_db_user.yml
+      vars:
+        db_user: "{{ replicator_db_user|default(default_replicator_db_user) }}"
+        role_attr_flags: "replication"
   tags:
     - database
     - backup


### PR DESCRIPTION
Without these the roles/users the slim dump's table ownership gets
assigned the the active user, 'postgres'. This ownership causes issues
when trying to use the loaded slim dump in development.

Fixes #481 