### PR TITLE
Remove postgresql backup for staging server

### DIFF
--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -37,9 +37,6 @@ staging-files00.cnx.org
 [staging_files01]
 staging-files01.cnx.org
 
-[backup2]
-backup2.cnx.org
-
 # Grouped Hosts
 
 [nfs:children]


### PR DESCRIPTION
It was originally added for testing.  Now that backup is set up for
production, I think we can remove this.