### PR TITLE
Change slim dump to use master database (prod09)

### DIFF
--- a/environments/prod/host_vars/backup2.cnx.org
+++ b/environments/prod/host_vars/backup2.cnx.org
@@ -1,4 +1,2 @@
 ---
 slim_dumps: yes
-# Point at the replicant:
-archive_db_host: prod10.cnx.org


### PR DESCRIPTION
When running the slim dump cron job against the database replicant prod10 by
hand, it kept running into this error:

```
pg_dump: Dumping the contents of table "files" failed: PQgetResult() failed.
pg_dump: Error message from server: ERROR:  canceling statement due to conflict with recovery
DETAIL:  User query might have needed to see row versions that must be removed.
pg_dump: The command was: COPY public.files (fileid, md5, file, sha1, media_type) TO stdout;
```

It appears that this error occurs when the database is not the master
one.  The cron job already succeeded once with prod09 and hopefully will
continue to create slim dumps when the weekly cron job kicks in.