### PR TITLE
Fix copy database

### DIFF
--- a/copy_database.yml
+++ b/copy_database.yml
@@ -92,4 +92,4 @@
         #     Error: Invalid data directory
         # This appears to be a problem after a postgresql-common update
         PGHOST: "{{ archive_db_host }}"
-      command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-db migrate"
+      command: "/var/cnx/venvs/publishing/bin/dbmigrator --db-connection-string='postgresql://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ db_name }}' --config /etc/cnx/publishing/app.ini --context cnx-db migrate"

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -3,7 +3,9 @@
 # This will dump the data into a new database, initialize db-migrator and migrate the data/schema.
 
 - name: get database details
-  hosts: database
+  hosts:
+    - database
+    - publishing
   vars_prompt:
     - name: "source_db_host"
       prompt: "Where is the database hosted?"

--- a/copy_database.yml
+++ b/copy_database.yml
@@ -25,6 +25,8 @@
         source_db_port: "{{ source_db_port }}"
         source_db_name: "{{ db_name }}"
         db_name: "{{ db_name }}_new"
+  tags:
+    - db-details
 
 - name: disable replicant
   hosts: replicant
@@ -39,6 +41,8 @@
       file:
         path: /var/lib/postgresql/{{ postgres_version }}/main/
         state: absent
+  tags:
+    - db-disable-repl
 
 - name: transfer database
   hosts: database
@@ -66,6 +70,8 @@
       become: yes
       become_user: postgres
       shell: "psql -U postgres -d {{ db_name }} -c 'DROP SCHEMA IF EXISTS venv CASCADE;'"
+  tags:
+    - db-transfer
 
 - name: set up venv and migrate database
   hosts: publishing
@@ -93,3 +99,5 @@
         # This appears to be a problem after a postgresql-common update
         PGHOST: "{{ archive_db_host }}"
       command: "/var/cnx/venvs/publishing/bin/dbmigrator --db-connection-string='postgresql://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ db_name }}' --config /etc/cnx/publishing/app.ini --context cnx-db migrate"
+  tags:
+    - db-migrate

--- a/swap_datafs.yml
+++ b/swap_datafs.yml
@@ -55,8 +55,6 @@
         chdir: "/var/lib/cnx/cnx-buildout"
     - name: update pdf_gen settings
       import_tasks: tasks/assign_pdf_gen_settings.yml
-    - name: set up localFS PDF folders
-      import_tasks: tasks/set_up_localfs_folders.yml
 
 - name: start zclient applications
   hosts: zclient


### PR DESCRIPTION
- Set facts for database and publishing in copy_database.yml

  `db_name` was not defined for publishing because it was only set for database.
  This causes the environment variables to not be set later on when initializing
  venv in the database and raises this error:
  
  ```
  TASK [rerun cnx-db venv] *********************************************************************
  fatal: [staging08.cnx.org]: FAILED! => {"changed": true, "cmd": ["/var/cnx/venvs/publishing/bin/cnx-db", "venv"], "delta": "0:00:09.093241", "end": "2018-01-23 22:55:06.663113", "msg": "non-zero return code", "rc": 4, "start": "2018-01-23 22:54:57.569872", "stderr": "'DB_URL' environment variable OR the 'db.common.url' setting MUST be defined", "stderr_lines": ["'DB_URL' environment variable OR the 'db.common.url' setting MUST be defined"], "stdout": "", "stdout_lines": []}
  ```

- Set the correct db url when migrating in copy_database.yml

  Instead of using the db settings in `/etc/cnx/publishing/app.ini` for migrating
  the database, we need to use the one we just copied.
  
  ```
  TASK [migrate database] *******************************************************************************************************************************************************************************************
  fatal: [staging08.cnx.org]: FAILED! => {"changed": true, "cmd": ["/var/cnx/venvs/publishing/bin/dbmigrator", "--config", "/etc/cnx/archive/app.ini", "--context", "cnx-db", "migrate"], "delta": "0:00:01.453792",
  "end": "2018-01-24 11:41:53.236355", "msg": "non-zero return code", "rc": 1, "start": "2018-01-24 11:41:51.782563", "stderr": "Traceback (most recent call last):\n  File \"/var/cnx/venvs/publishing/bin/dbmigrato
  r\", line 11, in <module>\n    sys.exit(main())\n  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/cli.py\", line 116, in main\n    return args['cmmd'](**args)\n  File \"/var/cnx/ve
  nvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 153, in wrapper\n    with db_connect(db_conn_str) as db_conn:\n  File \"/usr/lib/python2.7/contextlib.py\", line 17, in __enter__\n
   return self.gen.next()\n  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 54, in db_connect\n    db_conn = psycopg2.connect(*args, **kwargs)\n  File \"/var/cnx/ven
  vs/publishing/local/lib/python2.7/site-packages/psycopg2/__init__.py\", line 130, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\n  File \"/var/cnx/venvs/publishing/local/
  lib/python2.7/site-packages/dbmigrator/utils.py\", line 85, in wait_select_inter\n    state = conn.poll()\npsycopg2.OperationalError: FATAL:  database \"repository\" does not exist", "stderr_lines": ["Traceback
  (most recent call last):", "  File \"/var/cnx/venvs/publishing/bin/dbmigrator\", line 11, in <module>", "    sys.exit(main())", "  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/cli.py\", line 116, in main", "    return args['cmmd'](**args)", "  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 153, in wrapper", "    with db_connect(db_conn_st$
  ) as db_conn:", "  File \"/usr/lib/python2.7/contextlib.py\", line 17, in __enter__", "    return self.gen.next()", "  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", l$
  ne 54, in db_connect", "    db_conn = psycopg2.connect(*args, **kwargs)", "  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/psycopg2/__init__.py\", line 130, in connect", "    conn = _connec$
  (dsn, connection_factory=connection_factory, **kwasync)", "  File \"/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/dbmigrator/utils.py\", line 85, in wait_select_inter", "    state = conn.poll()", $
  psycopg2.OperationalError: FATAL:  database \"repository\" does not exist"], "stdout": "", "stdout_lines": []}
  ```
