### PR TITLE
contentXX servers should be production-like

### DIFF
--- a/environments/content01/files
+++ b/environments/content01/files
@@ -1,1 +1,1 @@
-../__dev_envs/files
+../__prod_envs/files

--- a/environments/content02/files
+++ b/environments/content02/files
@@ -1,1 +1,1 @@
-../__dev_envs/files
+../__prod_envs/files

--- a/environments/content03/files
+++ b/environments/content03/files
@@ -1,1 +1,1 @@
-../__dev_envs/files
+../__prod_envs/files

--- a/environments/content04/files
+++ b/environments/content04/files
@@ -1,1 +1,1 @@
-../__dev_envs/files
+../__prod_envs/files

--- a/environments/content05/files
+++ b/environments/content05/files
@@ -1,1 +1,1 @@
-../__dev_envs/files
+../__prod_envs/files


### PR DESCRIPTION
Confirmed with @openstaxalina, the contentXX environments/servers should be production servers: they will be used by XML vendors for content work.

AFAIK, content01 and content02 have been deployed, but not yet released to vendor hands. Now is the time to fix them. :-)