### PR TITLE
make http -> https redirect permanent: 301 not 302

### DIFF
--- a/roles/lead_load_balancer/tasks/main.yml
+++ b/roles/lead_load_balancer/tasks/main.yml
@@ -32,9 +32,9 @@
         acl has_www hdr_beg(host) -i www 
         acl from_zope src 127.0.0.1 {% for host in groups.zope %}{{ hostvars[host].ansible_default_ipv4.address }} {% endfor %}
 
-        http-request redirect scheme https if ! from_zope ! { ssl_fc }
-        http-request redirect prefix http://{{ frontend_domain }}%[req.uri] if has_www ! { ssl_fc }
-        http-request redirect prefix https://{{ frontend_domain }}%[req.uri] if has_www { ssl_fc }
+        http-request redirect scheme https code 301 if ! from_zope ! { ssl_fc }
+        http-request redirect prefix http://{{ frontend_domain }}%[req.uri] code 301 if has_www ! { ssl_fc }
+        http-request redirect prefix https://{{ frontend_domain }}%[req.uri] code 301 if has_www { ssl_fc }
 
         use_backend legacy_nodes if is_legacy
         use_backend nodes if is_cnxorg


### PR DESCRIPTION
This handles _just_ the lead-load balancer http -> https redirect. This is related to critsit #x-20180210-cnxsearch