### PR TITLE
Add deploy instructions for the Press application

### DIFF
--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -18,6 +18,12 @@ authoring_db_password: "{{ vault_authoring_db_password }}"
 authoring_db_host: dev00.cnx.org
 authoring_db_port: 5432
 
+press_db_name: "{{ archive_db_name }}",
+press_db_user: "{{ archive_db_user }}",
+press_db_password: "{{ archive_db_password }}",
+press_db_host: "{{ archive_db_host }}",
+press_db_port: "{{ archive_db_port }}"
+
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.
 # 'hosts' is a space separated value containing hostnames or ip addresses

--- a/environments/dev/inventory
+++ b/environments/dev/inventory
@@ -69,6 +69,9 @@ dev03
 
 [backup:children]
 
+[press:children]
+dev00
+
 # Groups of groups
 
 [broker_connected:children]
@@ -85,12 +88,14 @@ authoring
 zclient
 pdf_gen
 backup
+press
 
 [nfs_connected:children]
 legacy_frontend
 frontend
 zclient
 pdf_gen
+press
 
 [zope:children]
 zeo
@@ -100,3 +105,4 @@ pdf_gen
 [varnish_purge_allowed:children]
 zope
 publishing
+press

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -16,6 +16,12 @@ authoring_db_password: cnxauthoring
 authoring_db_host: localhost
 authoring_db_port: 5432
 
+press_db_name: "{{ archive_db_name }}",
+press_db_user: "{{ archive_db_user }}",
+press_db_password: "{{ archive_db_password }}",
+press_db_host: "{{ archive_db_host }}",
+press_db_port: "{{ archive_db_port }}"
+
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.
 # 'hosts' is a space separated value containing hostnames or ip addresses

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -54,6 +54,9 @@ zope.local.cnx.org
 
 [backup:children]
 
+[press:children]
+local.cnx.org
+
 # Groups of groups
 
 [broker_connected:children]
@@ -70,6 +73,7 @@ authoring
 zclient
 pdf_gen
 backup
+press
 
 [nfs_connected:children]
 archive
@@ -79,6 +83,7 @@ publishing_worker
 frontend
 zclient
 pdf_gen
+press
 
 [zope:children]
 zeo
@@ -88,3 +93,4 @@ pdf_gen
 [varnish_purge_allowed:children]
 zope
 publishing
+press

--- a/main.yml
+++ b/main.yml
@@ -32,6 +32,7 @@
 - import_playbook: channel_processing.yml
 - import_playbook: publishing_worker.yml
 - import_playbook: authoring.yml
+- import_playbook: press.yml
 
 - import_playbook: zope.yml not_standalone=yes
   tags:

--- a/press.yml
+++ b/press.yml
@@ -1,0 +1,9 @@
+---
+
+- name: install press
+  hosts: press
+  roles:
+    - press
+  tags:
+    - press
+    - be

--- a/roles/archive/meta/main.yml
+++ b/roles/archive/meta/main.yml
@@ -2,6 +2,7 @@
 
 dependencies:
   - _pgdg_repo
+  - libxml
   - python2
   - memcached
   - supervisord

--- a/roles/archive/tasks/main.yml
+++ b/roles/archive/tasks/main.yml
@@ -16,8 +16,6 @@
     - build-essential
     - git
     - libpq-dev
-    - libxml2-dev
-    - libxslt-dev
     - zlib1g-dev
 
 - name: install postgres client

--- a/roles/authoring/meta/main.yml
+++ b/roles/authoring/meta/main.yml
@@ -2,6 +2,7 @@
 
 dependencies:
   - _pgdg_repo
+  - libxml
   - python2
   - memcached
   - supervisord

--- a/roles/authoring/tasks/main.yml
+++ b/roles/authoring/tasks/main.yml
@@ -15,8 +15,6 @@
     state: present
   with_items:
     - build-essential
-    - libxml2-dev
-    - libxslt-dev
     - zlib1g-dev
 
 - name: install postgres client

--- a/roles/cnx_database/meta/main.yml
+++ b/roles/cnx_database/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 
 dependencies:
+  - libxml
   - postgres
   - plxslt
   - python2

--- a/roles/cnx_database/tasks/plpython_imports.yml
+++ b/roles/cnx_database/tasks/plpython_imports.yml
@@ -22,8 +22,6 @@
     - build-essential
     - git
     - libpq-dev
-    - libxml2-dev
-    - libxslt-dev
     - zlib1g-dev
 
 # +++

--- a/roles/jre8/tasks/main.yml
+++ b/roles/jre8/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: install OpenJDK 8 JRE headless
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - openjdk-8-jre-headless

--- a/roles/libxml/tasks/main.yml
+++ b/roles/libxml/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: install xml libraries
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - build-essential
+    - libxml2-dev
+    - libxslt-dev

--- a/roles/plxslt/meta/main.yml
+++ b/roles/plxslt/meta/main.yml
@@ -1,0 +1,4 @@
+---
+
+dependencies:
+  - libxml

--- a/roles/plxslt/tasks/install_plxslt.yml
+++ b/roles/plxslt/tasks/install_plxslt.yml
@@ -8,8 +8,6 @@
     state: present
   with_items:
     - build-essential
-    - libxml2-dev
-    - libxslt-dev
     # pkg-config is required for plxslt builds
     - pkg-config
     # unzip is needed for the source acquisition step

--- a/roles/press/handlers/main.yml
+++ b/roles/press/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: list supervisor applications
+  become: yes
+  command: supervisorctl avail
+  register: supervisorctl_avail
+
+- name: restart press
+  become: yes
+  supervisorctl:
+    name: "press"
+    state: restarted
+  when: supervisorctl_avail.stdout.find('press') != -1

--- a/roles/press/meta/main.yml
+++ b/roles/press/meta/main.yml
@@ -3,5 +3,6 @@
 dependencies:
   - _pgdg_repo
   - jre8
+  - libxml
   - python3
   - supervisord

--- a/roles/press/meta/main.yml
+++ b/roles/press/meta/main.yml
@@ -2,5 +2,6 @@
 
 dependencies:
   - _pgdg_repo
+  - jre8
   - python3
   - supervisord

--- a/roles/press/meta/main.yml
+++ b/roles/press/meta/main.yml
@@ -1,0 +1,6 @@
+---
+
+dependencies:
+  - _pgdg_repo
+  - python3
+  - supervisord

--- a/roles/press/tasks/main.yml
+++ b/roles/press/tasks/main.yml
@@ -14,8 +14,6 @@
     - build-essential
     - git
     - libpq-dev
-    - libxml2-dev
-    - libxslt-dev
     - zlib1g-dev
 
 - name: install postgres client

--- a/roles/press/tasks/main.yml
+++ b/roles/press/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+# Installs Press
+
+# +++
+# Prerequisites
+# +++
+
+- name: install system level dependencies
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - openjdk-8-jre-headless
+    - build-essential
+    - git
+    - libpq-dev
+    - libxml2-dev
+    - libxslt-dev
+    - zlib1g-dev
+
+- name: install postgres client
+  become: yes
+  apt:
+    name: "postgresql-client-{{ postgres_version }}"
+    state: present
+
+# +++
+# Install virtualenv(s)
+# +++
+
+- stat:
+    path: "/var/cnx/venvs"
+  register: venvs_dir
+
+- name: ensure the venvs directory exists
+  become: yes
+  when: not venvs_dir.stat.exists
+  file:
+    path: "/var/cnx/venvs"
+    state: directory
+    mode: 0755
+    owner: www-data
+
+- name: set the owner of venvs directory
+  become: yes
+  file:
+    path: "/var/cnx/venvs"
+    state: directory
+    recurse: yes
+    owner: www-data
+
+- name: create the venv
+  become: yes
+  become_user: www-data
+  command: "python3 -m venv /var/cnx/venvs/press"
+
+# +++
+# Install
+# +++
+
+- stat:
+    path: "/var/cnx/apps"
+  register: apps_dir
+
+- name: ensure the apps directory exists
+  become: yes
+  when: not apps_dir.stat.exists
+  file:
+    path: "/var/cnx/apps"
+    state: directory
+    mode: 0755
+    owner: www-data
+
+- name: set the owner of apps directory
+  become: yes
+  file:
+    path: "/var/cnx/apps"
+    state: directory
+    recurse: yes
+    owner: www-data
+
+- name: checkout codebase
+  become: yes
+  become_user: www-data
+  git:
+    repo: "https://github.com/Connexions/cnx-press.git"
+    dest: "/var/cnx/apps/press"
+    version: "{{ press_version|default('HEAD') }}"
+
+- name: install dependencies
+  become: yes
+  become_user: www-data
+  pip:
+    virtualenv: "/var/cnx/venvs/press"
+    requirements: "/var/cnx/apps/press/requirements/{{ item }}"
+  with_items:
+    - "main.txt"
+    - "deploy.txt"
+
+# +++
+# Configure
+# +++
+
+- name: ensure the etc directories exists
+  become: yes
+  file:
+    path: "/etc/{{ item }}"
+    state: directory
+    mode: 0755
+  with_items:
+    - cnx
+    - cnx/press
+
+- name: render configuration
+  become: yes
+  template:
+    src: "{{ item }}"
+    dest: "/{{ item }}"
+    mode: 0644
+    owner: root
+    group: root
+  with_items:
+    - "etc/cnx/press/vars.sh"
+  notify:
+    - list supervisor applications
+    - restart press
+
+# +++
+# Init service
+# +++
+
+- name: configure press under supervisor
+  become: yes
+  template:
+    src: etc/supervisor/conf.d/press.conf
+    dest: "/etc/supervisor/conf.d/press.conf"
+    mode: 0644
+  notify:
+    - reload supervisord

--- a/roles/press/tasks/main.yml
+++ b/roles/press/tasks/main.yml
@@ -11,7 +11,6 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - openjdk-8-jre-headless
     - build-essential
     - git
     - libpq-dev

--- a/roles/press/templates/etc/cnx/press/vars.sh
+++ b/roles/press/templates/etc/cnx/press/vars.sh
@@ -1,0 +1,6 @@
+# this is a shell script which can be sourced into other scripts
+# to provide access to configuration values specific to this application
+
+SHARED_DIR="/var/cnx/apps/var"
+DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
+DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"

--- a/roles/press/templates/etc/supervisor/conf.d/press.conf
+++ b/roles/press/templates/etc/supervisor/conf.d/press.conf
@@ -1,0 +1,7 @@
+[program:press]
+user=www-data
+directory=/var/cnx/apps/press
+numprocs={{ hostvars[inventory_hostname].press_count|default(1) }}
+process_name=%(program_name)s-%(process_num)s
+environment=SHARED_DIR="/var/cnx/apps/press/var",DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}",DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
+command=/var/cnx/venvs/press/bin/gunicorn -b 0.0.0.0:6543 --access-logfile - --error-logfile - -n press --reload wsgi:app

--- a/roles/publishing_common/meta/main.yml
+++ b/roles/publishing_common/meta/main.yml
@@ -2,6 +2,7 @@
 
 dependencies:
   - _pgdg_repo
+  - libxml
   - python2
   - repository_db
   - memcached

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -16,8 +16,6 @@
     - build-essential
     - git
     - libpq-dev
-    - libxml2-dev
-    - libxslt-dev
     - zlib1g-dev
 
 - name: install postgres client

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# Install Python 3.x
+
+- name: install python 3.x
+  become: yes
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "python3-dev"
+    - "python3-venv"

--- a/roles/zope_common/meta/main.yml
+++ b/roles/zope_common/meta/main.yml
@@ -2,5 +2,6 @@
 
 dependencies:
   - _pgdg_repo
+  - jre8
   - python24
   - dtd_files

--- a/roles/zope_common/meta/main.yml
+++ b/roles/zope_common/meta/main.yml
@@ -3,5 +3,6 @@
 dependencies:
   - _pgdg_repo
   - jre8
+  - libxml
   - python24
   - dtd_files

--- a/roles/zope_common/tasks/install_cnx_buildout.yml
+++ b/roles/zope_common/tasks/install_cnx_buildout.yml
@@ -14,9 +14,6 @@
     - libjpeg-dev
     - libpng-dev
     - build-essential
-    # lxml dependencies
-    - libxml2-dev
-    - libxslt1-dev
   tags: buildout-apt
 
 # +++

--- a/roles/zope_common/tasks/install_cnx_buildout.yml
+++ b/roles/zope_common/tasks/install_cnx_buildout.yml
@@ -11,7 +11,6 @@
     state: present
   become: yes
   with_items:
-    - openjdk-8-jre-headless
     - libjpeg-dev
     - libpng-dev
     - build-essential


### PR DESCRIPTION
This adds the Press application, which has been developed to replace the legacy publishing behavior. Please let me know if you have any questions.

BTW, it's likely **best to read the commits individually** rather than parsing through the changes all together. The refactor commits make the changeset look messy. 