### PR TITLE
Modify python3 role to use python 3.6

### DIFF
--- a/roles/press/tasks/main.yml
+++ b/roles/press/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: create the venv
   become: yes
   become_user: www-data
-  command: "python3 -m venv /var/cnx/venvs/press"
+  command: "python3.6 -m venv /var/cnx/venvs/press"
 
 # +++
 # Install

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -1,11 +1,15 @@
 ---
 # Install Python 3.x
 
-- name: install python 3.x
+- name: add deadsnakes ppa
+  apt_repository:
+    repo: 'ppa:deadsnakes/ppa'
+
+- name: install python 3.6
   become: yes
   apt:
     name: "{{ item }}"
     state: present
   with_items:
-    - "python3-dev"
-    - "python3-venv"
+    - "python3.6-dev"
+    - "python3.6-venv"


### PR DESCRIPTION
The wrong python version is installed. Python >=3.6 is required and Python 3.5 was installed. This change corrects that.

We'll need to `rm -rf /var/cnx/venvs/press` before a deploy of this.

This is an untested commit.
