### PR TITLE
Archive robots txt

### DIFF
--- a/environments/prod/group_vars/all/robots_txt.yml
+++ b/environments/prod/group_vars/all/robots_txt.yml
@@ -23,3 +23,9 @@ robots_txt:
     - /lens_add
     - /*/lens_view/*$
     - /content/*view_mode=statistics$
+
+archive_robots_txt:
+  user_agents:
+    - {name: '*'}
+  allow_list:
+    - /

--- a/environments/staging/group_vars/all/robots_txt.yml
+++ b/environments/staging/group_vars/all/robots_txt.yml
@@ -8,3 +8,9 @@ robots_txt:
     - {name: 'Slurp', crawl_delay: 10}
   disallow_list:
     - /
+archive_robots_txt:
+  user_agents:
+    - {name: '*'}
+    - {name: 'ARCHIVE TESTING', crawl_delay: 10}
+  disallow_list:
+    - /

--- a/roles/robots_txt/defaults/main.yml
+++ b/roles/robots_txt/defaults/main.yml
@@ -4,3 +4,8 @@ robots_txt:
     - {name: '*'}
   disallow_list:
     - '/'
+archive_robots_txt:
+  user_agents:
+    - {name: '*'}
+  disallow_list:
+    - '/'

--- a/roles/robots_txt/tasks/main.yml
+++ b/roles/robots_txt/tasks/main.yml
@@ -1,11 +1,20 @@
 ---
 # Add cnx robots.txt
 
-- name: Add robots.txt
+- name: Add top level robots.txt
   become: yes
   template:
     src: var/www/webview/robots.txt
     dest: /var/www/webview/robots.txt
+    owner: www-data
+  tags:
+    - robots_txt
+
+- name: Add archive robots.txt
+  become: yes
+  template:
+    src: var/www/robots.txt
+    dest: /var/www/robots.txt
     owner: www-data
   tags:
     - robots_txt

--- a/roles/robots_txt/templates/var/www/robots.txt
+++ b/roles/robots_txt/templates/var/www/robots.txt
@@ -1,0 +1,20 @@
+{% if archive_robots_txt.sitemap_name is defined %}
+Sitemap: https://{{ frontend_domain }}/{{ robots_txt.sitemap_name }}
+{% endif %}
+{% for user_agent in archive_robots_txt.user_agents %}
+User-agent: {{ user_agent.name }}
+{% if user_agent.crawl_delay|default(None) %}
+Crawl-delay: {{ user_agent.crawl_delay }}
+{% endif %}
+{% if archive_robots_txt.disallow_list is defined %}
+{% for disallow in archive_robots_txt.disallow_list %}
+Disallow: {{ disallow }}
+{% endfor %}
+{% endif %}
+{% if archive_robots_txt.allow_list is defined %}
+{% for allow in archive_robots_txt.allow_list %}
+Allow: {{ allow }}
+{% endfor %}
+{% endif %}
+
+{% endfor %}

--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -176,15 +176,17 @@ sub vcl_recv {
 
     # cnx rewrite archive  - specials served from nginx statically
     if (req.http.host ~ "^{{ arclishing_domain }}" || req.url ~ "^/sitemap.*.xml") {
-        if ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
+        
+        if (req.url  == "/robots.txt" || req.url ~ "^/specials") {
+            set req.backend_hint = static_files;
+            return (hash);
+        }
+
+        elsif ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
             set req.backend_hint = publishing_cluster.backend(req.http.cookie);
             return (pass);
         }
 
-        elsif (req.url ~ "^/specials") {
-            set req.backend_hint = static_files;
-            return (hash);
-        }
         else {
 
         set req.backend_hint = archive_cluster.backend();


### PR DESCRIPTION
This adds a path for serving a different `robots.txt` for `archive.cnx.org`, and templating for it, under control of cnx-deploy.