### PR TITLE
Expose the press instance(s) to the outside world

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -8,6 +8,7 @@ postgres_version: 9.4
 default_archive_base_port: 6500
 default_publishing_base_port: 6600
 default_authoring_base_port: 6400
+default_press_base_port: 6700
 default_zclient_base_port: 8280
 
 # See http://docs.ansible.com/ansible/postgresql_user_module.html

--- a/roles/iptables/templates/etc/iptables
+++ b/roles/iptables/templates/etc/iptables
@@ -47,6 +47,7 @@
 {{ instance_ports(groups.zclient, zclient_base_port, default_zclient_base_port, hv.zclient_count) }}
 {{ instance_ports(groups.archive, archive_base_port, default_archive_base_port, hv.archive_count) }}
 {{ instance_ports(groups.publishing, publishing_base_port, default_publishing_base_port, hv.publishing_count) }}
+{{ instance_ports(groups.press, press_base_port, default_press_base_port, hv.press_count) }}
 
 {% if (inventory_hostname in groups.database or inventory_hostname in groups.replicant) -%}
     -A INPUT -p tcp --dport 5432 -m comment --comment "allowed Postgres client ports" -j  ACCEPT

--- a/roles/press/templates/etc/supervisor/conf.d/press.conf
+++ b/roles/press/templates/etc/supervisor/conf.d/press.conf
@@ -4,4 +4,4 @@ directory=/var/cnx/apps/press
 numprocs={{ hostvars[inventory_hostname].press_count|default(1) }}
 process_name=%(program_name)s-%(process_num)s
 environment=SHARED_DIR="/var/cnx/apps/press/var",DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}",DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}",SENTRY_DSN="{{ sentry_dsn|default() }}"
-command=/var/cnx/venvs/press/bin/gunicorn -b 0.0.0.0:6543 --access-logfile - --error-logfile - -n press --reload wsgi:app
+command=/var/cnx/venvs/press/bin/gunicorn -b 0.0.0.0:{{ press_base_port|default(default_press_base_port) }} --access-logfile - --error-logfile - -n press --reload wsgi:app


### PR DESCRIPTION
- This assigns a default port to the Press service, similar to how it's done with the other apps
- This punches a hole in the firewall to allow the request pipeline to communicate with Press instance(s). Currently, the service is blocked off from communication with the outside world.
- This exposes the Press service on cnx.org. 