### PR TITLE
Fix undefined variable 'press' for groups

### DIFF
--- a/environments/content01/inventory
+++ b/environments/content01/inventory
@@ -51,6 +51,8 @@ content01
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/content02/inventory
+++ b/environments/content02/inventory
@@ -51,6 +51,8 @@ content02
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/content03/inventory
+++ b/environments/content03/inventory
@@ -51,6 +51,8 @@ content03
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/content04/inventory
+++ b/environments/content04/inventory
@@ -51,6 +51,8 @@ content04
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/content05/inventory
+++ b/environments/content05/inventory
@@ -51,6 +51,8 @@ content05
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/des/inventory
+++ b/environments/des/inventory
@@ -67,6 +67,8 @@ des00
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/devb/inventory
+++ b/environments/devb/inventory
@@ -52,6 +52,8 @@ devb
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/katalyst01/inventory
+++ b/environments/katalyst01/inventory
@@ -52,6 +52,8 @@ katalyst01
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/legacy-staging/inventory
+++ b/environments/legacy-staging/inventory
@@ -39,6 +39,8 @@ legacy_staging
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [db_connected:children]

--- a/environments/prod/inventory
+++ b/environments/prod/inventory
@@ -93,6 +93,8 @@ prod06
 [backup:children]
 backup2
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/qa/inventory
+++ b/environments/qa/inventory
@@ -52,6 +52,8 @@ qa00
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -89,6 +89,8 @@ staging06
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]

--- a/environments/tea/inventory
+++ b/environments/tea/inventory
@@ -57,6 +57,8 @@ tea01
 
 [backup:children]
 
+[press:children]
+
 # Groups of groups
 
 [broker_connected:children]


### PR DESCRIPTION
Basically, add the group to all the environments.
This will then make it defined for any run.