### PR TITLE
Conditionally include Press in Varnish config

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -104,6 +104,8 @@ backend {{ backend_name }} {
 {% endfor %}
 {% endfor %}
 
+{# FIXME within an if condition because it's not production worthy yet #}
+{% if 'press' in groups and groups['press'] %}
 probe press_probe {
     .url = "/ping";
     .expected_response = 200;
@@ -125,6 +127,7 @@ backend {{ backend_name }} {
 
 {% endfor %}
 {% endfor %}
+{% endif %}
 
 acl purge {
     "localhost";
@@ -192,10 +195,12 @@ sub vcl_recv {
         return (pass);
     }
 
+{% if 'press' in groups and groups['press'] %}
     if (req.url ~ "^/api/") {
        set req.backend_hint = press_cluster.backend(req.http.cookie);
        return (pass);
     }
+{% endif %}
 
 {% if accounts_stub|default(False) %}
     # cnx rewrite stub login form


### PR DESCRIPTION
Place this configuration within a conditional block.
This fixes the varnish config, which
is complaining about an unused probe.
It also puts a condition around the route to press.