### PR TITLE
i18n added dictionary files that are served separately - 

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -447,6 +447,9 @@ sub vcl_backend_response {
     if (bereq.url ~ "^/scripts/(?:main|settings)[.]js$") {
         set beresp.http.Cache-Control = "max-age=3600";
     }
+    elsif (bereq.url ~ "^/locale") {
+        set beresp.http.Cache-Control = "max-age=3600";
+    }
     if (beresp.status >= 500) {
         set beresp.ttl = 0s;
     }


### PR DESCRIPTION
add cache-control max-age that matches the js files (1 hour) This means that after any deploy, all browser caches will be up-to-date no later than one hour post-deploy.