### PR TITLE
ansible filter in test syntax change

### DIFF
--- a/nfs.yml
+++ b/nfs.yml
@@ -28,7 +28,7 @@
         mode: 0644
       register: nfs_configuration
     - name: reload nfs
-      when: nfs_configuration|changed
+      when: nfs_configuration is changed
       service:
         name: nfs-kernel-server
         state: reloaded

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: install slim dump script
   become: yes
-  when: slim_dumps|default(False)
+  when: slim_dumps is default(False)
   template:
     src: usr/local/bin/cnx-slim-dump
     dest: /usr/local/bin/cnx-slim-dump
@@ -25,7 +25,7 @@
 
 - name: set up slim dumps
   become: yes
-  when: slim_dumps|default(False)
+  when: slim_dumps is default(False)
   file:
       src: /usr/local/bin/cnx-slim-dump
       dest: /etc/cron.weekly/cnx-slim-dump

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -3,7 +3,7 @@
   become: yes
   apt:
     name: iptables
-    state: installed
+    state: present
 
 - name: iptables chain setup
   become: yes

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -26,7 +26,7 @@
 # Because the default site uses port 80, we need to free it before the
 # handlers otherwise varnish won't be able to bind to port 80 on provisioning.
 - name: restart nginx
-  when: disabled_default_site|changed
+  when: disabled_default_site is changed
   become: yes
   service:
     name: nginx

--- a/roles/pdf_gen/tasks/main.yml
+++ b/roles/pdf_gen/tasks/main.yml
@@ -12,7 +12,7 @@
     - reload supervisord
 
 - name: restart pdf_gen
-  when: not supervisor_conf_for_pdf_gen|changed
+  when: not supervisor_conf_for_pdf_gen is changed
   become: yes
   supervisorctl:
     name: pdf_gen

--- a/roles/sysstat/tasks/main.yml
+++ b/roles/sysstat/tasks/main.yml
@@ -3,7 +3,7 @@
   become: yes
   apt:
     name: sysstat
-    state: installed
+    state: present
 
 - name: enable sysstat
   become: yes

--- a/roles/zclient/tasks/main.yml
+++ b/roles/zclient/tasks/main.yml
@@ -59,7 +59,7 @@
     - reload supervisord
 
 - name: restart zclients
-  when: not supervisor_conf_for_zclients|changed
+  when: not supervisor_conf_for_zclients is changed
   become: yes
   supervisorctl:
     name: "{{ item }}"

--- a/roles/zeo/meta/main.yml
+++ b/roles/zeo/meta/main.yml
@@ -5,4 +5,4 @@ dependencies:
   - role: zeopack
     # Default environments should have this, production should disable it
     # because the backup server does the packing during backup.
-    when: enable_zeopack|default(True)
+    when: enable_zeopack is default(True)

--- a/roles/zeo/tasks/main.yml
+++ b/roles/zeo/tasks/main.yml
@@ -16,7 +16,7 @@
     - reload supervisord
 
 - name: restart zeo
-  when: not supervisor_conf_for_zeo|changed
+  when: not supervisor_conf_for_zeo is changed
   become: yes
   supervisorctl:
     name: zeo

--- a/tasks/create_rhaptos_site.yml
+++ b/tasks/create_rhaptos_site.yml
@@ -8,7 +8,7 @@
   ignore_errors: True
 
 - name: create empty temporary rhaptos database
-  when: rhaptos_site|failed
+  when: rhaptos_site is failed
   vars:
     db_name: rhaptos
     db_owner: "{{ archive_db_user }}"
@@ -17,19 +17,19 @@
   import_tasks: tasks/create_db.yml
 
 - name: create rhaptos site
-  when: rhaptos_site|failed
+  when: rhaptos_site is failed
   shell: "./bin/instance run scripts/create_rhaptos_site.py plone Portal postgres {{ archive_db_user }} rhaptos {{ archive_db_host }} {{ archive_db_port }}"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
 
 - name: update database connection string in rhaptos site
-  when: rhaptos_site|failed
+  when: rhaptos_site is failed
   shell: echo 'import transaction; app.plone.rhaptosDA.connection_string = "postgres://{{ archive_db_user }}:{{ archive_db_password }}@{{ archive_db_host }}:{{ archive_db_port }}/{{ archive_db_name }}"; transaction.commit()' | ./bin/instance debug
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
 
 - name: remove temporary rhaptos database
-  when: rhaptos_site|failed
+  when: rhaptos_site is failed
   postgresql_db:
     name: rhaptos
     login_host: "{{ archive_db_host }}"
@@ -37,7 +37,7 @@
     state: absent
 
 - name: assign pdf_gen settings
-  when: rhaptos_site|failed
+  when: rhaptos_site is failed
   import_tasks: tasks/assign_pdf_gen_settings.yml
   tags:
     - zope


### PR DESCRIPTION
This catches one of the cases that ansible 2.5 griped about being deprecated now, in our playbooks