### PR TITLE
Change connexions-cnxml package to the "any" version for mathml3 support

### DIFF
--- a/roles/dtd_files/tasks/main.yml
+++ b/roles/dtd_files/tasks/main.yml
@@ -39,12 +39,13 @@
     state: present
     force: yes
   with_items:
-    - connexions-cnxml-0.7
+    - connexions-cnxml-any
     - connexions-mdml-0.5
     - connexions-memcases-xml
     - connexions-qml-1.0
     - connexions-bibtexml-1.0
     - connexions-mathml-2.0
+    - connexions-mathml-3.0
     - connexions-collxml-1.0
   tags:
     - install-cnxml-dtd-pkgs


### PR DESCRIPTION
This updates to connexions-cnxml-any package, and installs connexions-mathml3 as well.
These packages ~are not yet~ have been hand deployed to packages.cnx.org, so it is safe to merge.