### PR TITLE
trust our insecure packages repo

### DIFF
--- a/roles/dtd_files/tasks/main.yml
+++ b/roles/dtd_files/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: add cnx apt repo
   become: yes
   apt_repository:
-    repo: "deb http://packages.cnx.org/ deb/"
+    repo: "deb [ trusted=yes ] http://packages.cnx.org/ deb/"
     state: present
   tags:
     - install-cnxml-dtd-pkgs


### PR DESCRIPTION
This will delay the need to create a proper debian (signed) package repo