### PR TITLE
switch to multiple cnxml version packages

### DIFF
--- a/roles/dtd_files/tasks/main.yml
+++ b/roles/dtd_files/tasks/main.yml
@@ -39,7 +39,8 @@
     state: present
     force: yes
   with_items:
-    - connexions-cnxml-any
+    - connexions-cnxml-0.8
+    - connexions-cnxml-0.7
     - connexions-mdml-0.5
     - connexions-memcases-xml
     - connexions-qml-1.0


### PR DESCRIPTION
Support mathml3 via simultaneous install of 0.7 and 0.8 - select in schema code to validate