### PR TITLE
Pipe litezip publishing requests directly to Press

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -198,7 +198,9 @@ sub vcl_recv {
 {% if 'press' in groups and groups['press'] %}
     if (req.url ~ "^/api/") {
        set req.backend_hint = press_cluster.backend(req.http.cookie);
-       return (pass);
+       # let the client talk directly to Press,
+       # because litezip publishing payloads are huge.
+       return (pipe);
     }
 {% endif %}
 


### PR DESCRIPTION
This will take varnish out of the mix. According to the documentation,
this turns varnish into a TCP proxy for this particular client's request.
Essentially it fairies packets around without inspecting them and allows
for the connection to stay open until closed by either the client or server.

Follow up to #528 