### PR TITLE
Enabled iptables for dev servers. 

### DIFF
--- a/environments/dev/group_vars/all/vars.yml
+++ b/environments/dev/group_vars/all/vars.yml
@@ -26,6 +26,8 @@ press_db_port: "{{ archive_db_port }}"
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 
+install_iptables: True
+
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.
 # 'hosts' is a space separated value containing hostnames or ip addresses

--- a/iptables.yml
+++ b/iptables.yml
@@ -1,15 +1,12 @@
 ---
-- name: setup of iptables
+- name: setup iptables
   hosts: all:!local
   gather_facts: no
   roles:
     - role: iptables
       when:
-        - install_firewall is defined
-        - install_firewall|bool
+        - install_iptables is defined
       tags:
         - iptables
-        - firewall
   tags:
     - iptables
-    - firewall

--- a/main.yml
+++ b/main.yml
@@ -66,7 +66,6 @@
 - import_playbook: iptables.yml
   tags:
     - iptables
-    - firewall
 
 - import_playbook: sysstat.yml
   tags:


### PR DESCRIPTION
Changes to enable iptables role for dev servers, also clean up firewall tag that was used in only one place. It looks like all the work was already done.