### PR TITLE
add press deployment to devb

### DIFF
--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -17,6 +17,12 @@ authoring_db_password: "{{ vault_authoring_db_password }}"
 authoring_db_host: "{{ _host_prefix }}.cnx.org"
 authoring_db_port: 5432
 
+press_db_name: "{{ archive_db_name }}"
+press_db_user: "{{ archive_db_user }}"
+press_db_password: "{{ archive_db_password }}"
+press_db_host: "{{ archive_db_host }}"
+press_db_port: "{{ archive_db_port }}"
+
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.
 # 'hosts' is a space separated value containing hostnames or ip addresses

--- a/environments/devb/inventory
+++ b/environments/devb/inventory
@@ -53,6 +53,7 @@ devb
 [backup:children]
 
 [press:children]
+devb
 
 # Groups of groups
 
@@ -70,6 +71,7 @@ authoring
 zclient
 pdf_gen
 backup
+press
 
 [nfs_connected:children]
 archive
@@ -78,6 +80,7 @@ legacy_frontend
 frontend
 zclient
 pdf_gen
+press
 
 [zope:children]
 zeo
@@ -87,3 +90,4 @@ pdf_gen
 [varnish_purge_allowed:children]
 zope
 publishing
+press


### PR DESCRIPTION
devb is the textbook development and testing server. I'm guessing that at some point we will want press deployed there as well.