### PR TITLE
added a colon to the press group name

### DIFF
--- a/roles/press/handlers/main.yml
+++ b/roles/press/handlers/main.yml
@@ -8,6 +8,6 @@
 - name: restart press
   become: yes
   supervisorctl:
-    name: "press"
+    name: "press:"
     state: restarted
   when: supervisorctl_avail.stdout.find('press') != -1


### PR DESCRIPTION
Press is part of a group and therefore the `supervisorctl` module needs the colon to correctly ID and restart the process. 