### PR TITLE
Pin Press from v3.1.0 to v3.2.3

### DIFF
--- a/environments/__prod_envs/vars/versions.yml
+++ b/environments/__prod_envs/vars/versions.yml
@@ -1,3 +1,3 @@
 ---
 webview_version: v0.30.0
-press_version: v3.1.0
+press_version: v3.2.3


### PR DESCRIPTION
<details>
  <summary>changelog</summary>

```
3.2.3
-----

- One more attempt to address legacy enqueuing read timeouts (caused
  by DB conflicts in zope) by retrying failed enqueuing attempts.

3.2.2
-----

- Address legacy enqueuing read timeouts by sorting the content so that
  the collection is sent first. All other requests can timeout
  without concern. This only addresses the problem and does not fully
  resolve it.
  See https://github.com/Connexions/cnx-press/issues/100

3.2.1
-----

- Fix internal usage of the version by consistently using a version
  tuple (major and minor) between functions rather than the legacy version.

3.2.0
-----

- Add a publication finished event subscriber that purges the cache
  for legacy urls that contain the 'latest' version classifier.
```

</details>