### PR TITLE
Added zeopack wrapper script to automatically delete the old Data file when packing is successful

### DIFF
--- a/roles/zeopack/defaults/main.yml
+++ b/roles/zeopack/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+cnx_buildout_dir: /var/lib/cnx/cnx-buildout
+zeopack_dir: "{{ cnx_buildout_dir }}/bin"
+zeopack_filepath: "{{ zeopack_dir }}/zeopack"
+zeopack_old_data_filepath: "{{ cnx_buildout_dir }}/var/filestorage/Data.fs.old"
+zeopack_wrapper_filepath: "{{ zeopack_dir }}/zeopack-wrapper.sh"

--- a/roles/zeopack/tasks/main.yml
+++ b/roles/zeopack/tasks/main.yml
@@ -6,6 +6,7 @@
     dest: "{{ zeopack_wrapper_filepath }}"
     owner: www-data
     group: www-data
+    mode: 0755
 
 - name: create zeopack cronjob
   become: yes

--- a/roles/zeopack/tasks/main.yml
+++ b/roles/zeopack/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: create zeopack wrapper script
+  become: yes
+  template:
+    src: zeopack-wrapper.sh
+    dest: "{{ zeopack_wrapper_filepath }}"
+    owner: www-data
+    group: www-data
 
 - name: create zeopack cronjob
   become: yes
@@ -6,5 +13,5 @@
     name: zeopack
     state: present
     special_time: weekly
-    job: "/var/lib/cnx/cnx-buildout/bin/zeopack"
-    user: "www-data"
+    job: "{{ zeopack_wrapper_filepath }}"
+    user: www-data

--- a/roles/zeopack/templates/zeopack-wrapper.sh
+++ b/roles/zeopack/templates/zeopack-wrapper.sh
@@ -2,6 +2,6 @@
 {{ zeopack_filepath }}
 exit_status=$?
 if [ $exit_status -eq 0 ]; then
-    rm {{ zeopack_old_data_filepath }}
+    rm -f {{ zeopack_old_data_filepath }}
 fi
 exit $exit_status

--- a/roles/zeopack/templates/zeopack-wrapper.sh
+++ b/roles/zeopack/templates/zeopack-wrapper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+{{ zeopack_filepath }}
+exit_status=$?
+if [ $exit_status -eq 0 ]; then
+    rm {{ zeopack_old_data_filepath }}
+fi
+exit $exit_status


### PR DESCRIPTION
Tested successfully on -dev (the script was manually executed, the cron job was not tested but it should just work :tm:).

0755 means world readable, but that's what the cnx-buildout dir is currently set to.