### PR TITLE
Add missing legacy_varnish_port variable definitions

### DIFF
--- a/environments/prod/group_vars/all/vars.yml
+++ b/environments/prod/group_vars/all/vars.yml
@@ -21,6 +21,7 @@ sentry_dsn: "{{ vault_sentry_dsn }}"
 memcached_hosts: localhost
 
 varnish_port: 80
+legacy_varnish_port: 8991
 
 archive_base_port: "{{ default_archive_base_port }}"
 publishing_base_port: "{{ default_publishing_base_port }}"

--- a/environments/staging/group_vars/all/vars.yml
+++ b/environments/staging/group_vars/all/vars.yml
@@ -21,6 +21,8 @@ sentry_dsn: "{{ vault_sentry_dsn }}"
 memcached_hosts: localhost
 
 varnish_port: 80
+legacy_varnish_port: 8991
+
 
 # Points to the haproxy running on tundra
 archive_base_port: "{{ default_archive_base_port }}"


### PR DESCRIPTION
This adds the `legacy_varnish_port` variable value for prod and staging envs.