### PR TITLE
restore some legacy routes to varnish config - needed for latex pdf g…

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -255,9 +255,25 @@ sub vcl_recv {
             set req.backend_hint = legacy_frontend;
             return(pass);
         }
+        elsif (req.restarts == 0  && req.url ~ "^/content/col.*/?\?format=rdf") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
+        }
+        elsif (req.restarts == 0  && req.url ~ "^/content/.*/module_export_template") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
+        }
         elsif (req.restarts == 0  && req.url ~ "^/content/(m[0-9]+)/([0-9.]+)/.*format=pdf$") {
             set req.backend_hint = static_files;
             set req.url = regsub(req.url, "^/content/(m[0-9]+)/([0-9.]+)/.*format=pdf", "/files/\1-\2.pdf");
+        }
+        elsif (req.restarts == 1  && req.url ~ "^/files/(m[0-9]+)-([0-9.]+)\.pdf") {
+            set req.backend_hint = legacy_frontend;
+            set req.url = regsub(req.url, "^/files/(m[0-9]+)-([0-9.]+)\.pdf", "/content/\1/\2/?format=pdf");
+        }
+        elsif (req.url ~ "^/content/((col|m)[0-9]+)/latest/(pdf|epub)$") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
         }
         elsif (req.url ~ "^/content/((col|m)[0-9]+)/([0-9.]+)/(pdf|epub)$") {
             set req.backend_hint = static_files;


### PR DESCRIPTION
…eneration

Seems we _still_ can strip all the legacy out of the non-zope varnish: PDFgen expects certain things there.