### PR TITLE
Remove Press from the next prod-like deployment

### DIFF
--- a/environments/content01/inventory
+++ b/environments/content01/inventory
@@ -52,7 +52,7 @@ content01
 [backup:children]
 
 [press:children]
-content01
+# content01
 
 # Groups of groups
 

--- a/environments/content02/inventory
+++ b/environments/content02/inventory
@@ -52,7 +52,7 @@ content02
 [backup:children]
 
 [press:children]
-content02
+# content02
 
 # Groups of groups
 

--- a/environments/content03/inventory
+++ b/environments/content03/inventory
@@ -52,7 +52,7 @@ content03
 [backup:children]
 
 [press:children]
-content03
+# content03
 
 # Groups of groups
 

--- a/environments/content04/inventory
+++ b/environments/content04/inventory
@@ -52,7 +52,7 @@ content04
 [backup:children]
 
 [press:children]
-content04
+# content04
 
 # Groups of groups
 

--- a/environments/content05/inventory
+++ b/environments/content05/inventory
@@ -52,7 +52,7 @@ content05
 [backup:children]
 
 [press:children]
-content05
+# content05
 
 # Groups of groups
 

--- a/environments/prod/inventory
+++ b/environments/prod/inventory
@@ -94,7 +94,7 @@ prod06
 backup2
 
 [press:children]
-prod08
+# prod08
 
 # Groups of groups
 

--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -90,7 +90,7 @@ staging06
 [backup:children]
 
 [press:children]
-staging08
+# staging08
 
 # Groups of groups
 


### PR DESCRIPTION
A problem in the legacy software is preventing us from releasing. The problem stems from reading data from the database rather than legacy's usual role of writing to it.