### PR TITLE
Nfs firewall

### DIFF
--- a/roles/iptables/templates/etc/iptables
+++ b/roles/iptables/templates/etc/iptables
@@ -22,18 +22,15 @@
 {# default -#}
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m state --state RELATED,ESTABLISHED -m comment --comment "Accept established connections" -j ACCEPT
-{% for ipaddr in groups.nfs -%} 
-    -A INPUT -s {{ ipaddr }} -p tcp -m tcp -m comment --comment "Accept connection from NFS File Servers" -j ACCEPT
-    -A INPUT -s {{ groups.nfs_connected | join(',') }} -p tcp -m multiport --dports 2049 -m comment --comment "Accept connection from NFS CLinets" -j ACCEPT
-{% endfor -%}
 {# end default -#}
+
+-A INPUT -s {{ groups.nfs | join(',') ipaddr }} -p tcp -m tcp -m comment --comment "Accept connection from NFS File Servers" -j ACCEPT
+-A INPUT -s {{ groups.nfs_connected | join(',') }} -p tcp -m multiport --dports 2049 -m comment --comment "Accept connection from NFS Clients" -j ACCEPT
+
 {% for ipaddr in groups.legacy_frontend -%}
 -A INPUT -p tcp -m tcp -m multiport --dports 8080,8888,8991 -m comment --comment "allowed TCP ports for Legacy" -j ACCEPT
 {% endfor -%}
 
-{% for ipaddr in groups.nfs_connected -%}
--A INPUT -p tcp -m tcp -m multiport --dports 2049 -m comment --comment "allow TCP port 2049 for NFS connections" -j ACCEPT
-{% endfor -%}
 {% if ldap_enabled -%}
     -A INPUT -s 128.42.169.11/32 -p tcp -m tcp -m comment --comment "homedirs1.cnx.org" -j ACCEPT
 {% endif -%}

--- a/tasks/connect_nfs.yml
+++ b/tasks/connect_nfs.yml
@@ -25,7 +25,7 @@
     src: "{{ item.server }}:{{ item.src }}"
     name: "{{ item.name }}"
     fstype: nfs
-    opts: rw,soft,intr,timeo=1,retrans=3,actimeo=1,retry=0
+    opts: rw
     dump: 0
     passno: 2
     state: mounted


### PR DESCRIPTION
simplifies both client and server firewall rules - removes dups, and wide-open setting