### PR TITLE
Assign Press worker hosts

### DIFF
--- a/environments/content01/group_vars/all/vars.yml
+++ b/environments/content01/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/content01/inventory
+++ b/environments/content01/inventory
@@ -54,32 +54,36 @@ content01
 [press:children]
 content01
 
+[press_worker:children]
+content01
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/content02/group_vars/all/vars.yml
+++ b/environments/content02/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/content02/inventory
+++ b/environments/content02/inventory
@@ -54,32 +54,36 @@ content02
 [press:children]
 content02
 
+[press_worker:children]
+content02
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/content03/group_vars/all/vars.yml
+++ b/environments/content03/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/content03/inventory
+++ b/environments/content03/inventory
@@ -54,32 +54,36 @@ content03
 [press:children]
 content03
 
+[press_worker:children]
+content03
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/content04/group_vars/all/vars.yml
+++ b/environments/content04/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/content04/inventory
+++ b/environments/content04/inventory
@@ -54,32 +54,36 @@ content04
 [press:children]
 content04
 
+[press_worker:children]
+content04
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/content05/group_vars/all/vars.yml
+++ b/environments/content05/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/content05/inventory
+++ b/environments/content05/inventory
@@ -54,32 +54,36 @@ content05
 [press:children]
 content05
 
+[press_worker:children]
+content05
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/dev/inventory
+++ b/environments/dev/inventory
@@ -71,12 +71,17 @@ dev03
 [press:children]
 dev00
 
+[press_worker:children]
+dev00
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
@@ -87,6 +92,7 @@ zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
 legacy_frontend
@@ -94,6 +100,7 @@ frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -104,3 +111,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/devb/group_vars/all/vars.yml
+++ b/environments/devb/group_vars/all/vars.yml
@@ -22,8 +22,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/devb/inventory
+++ b/environments/devb/inventory
@@ -54,12 +54,17 @@ devb
 [press:children]
 devb
 
+[press_worker:children]
+devb
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
@@ -70,15 +75,15 @@ zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -89,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/katalyst01/group_vars/all/vars.yml
+++ b/environments/katalyst01/group_vars/all/vars.yml
@@ -22,8 +22,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.

--- a/environments/katalyst01/inventory
+++ b/environments/katalyst01/inventory
@@ -54,12 +54,17 @@ katalyst01
 [press:children]
 katalyst01
 
+[press_worker:children]
+katalyst01
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
@@ -70,15 +75,15 @@ zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -89,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/prod/inventory
+++ b/environments/prod/inventory
@@ -96,32 +96,36 @@ backup2
 [press:children]
 prod08
 
+[press_worker:children]
+prod08
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -132,3 +136,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/qa/group_vars/all/vars.yml
+++ b/environments/qa/group_vars/all/vars.yml
@@ -23,8 +23,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/qa/inventory
+++ b/environments/qa/inventory
@@ -54,12 +54,17 @@ qa00
 [press:children]
 qa00
 
+[press_worker:children]
+qa00
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
@@ -70,15 +75,15 @@ zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -89,4 +94,4 @@ pdf_gen
 zope
 publishing
 press
-
+press_worker

--- a/environments/staging/inventory
+++ b/environments/staging/inventory
@@ -92,32 +92,36 @@ staging06
 [press:children]
 staging08
 
+[press_worker:children]
+staging08
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -128,3 +132,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/tea/inventory
+++ b/environments/tea/inventory
@@ -65,22 +65,27 @@ tea01
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
+press
+press_worker
 
 [nfs_connected:children]
 legacy_frontend
 frontend
 zclient
 pdf_gen
+press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +95,5 @@ pdf_gen
 [varnish_purge_allowed:children]
 zope
 publishing
+press
+press_worker

--- a/environments/vendor-staging01/group_vars/all/vars.yml
+++ b/environments/vendor-staging01/group_vars/all/vars.yml
@@ -16,8 +16,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 sentry_dsn: "{{ vault_sentry_dsn }}"
 

--- a/environments/vendor-staging01/inventory
+++ b/environments/vendor-staging01/inventory
@@ -54,32 +54,36 @@ vendor-staging01
 [press:children]
 vendor-staging01
 
+[press_worker:children]
+vendor-staging01
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
 publishing
 channel_processing
 publishing_worker
-authoring
 zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -90,3 +94,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -21,8 +21,8 @@ press_db_user: "{{ archive_db_user }}"
 press_db_password: "{{ archive_db_password }}"
 press_db_host: "{{ archive_db_host }}"
 press_db_port: "{{ archive_db_port }}"
-press_broker_user: "{{ vault_press_broker_user }}"
-press_broker_password: "{{ vault_press_broker_password }}"
+press_broker_user: press
+press_broker_password: press
 
 # FIXME Not really yaml'ish to use space separated values...
 # Note, don't confuse the usage of 'hosts' here with ansible 'hosts'.

--- a/environments/vm/inventory
+++ b/environments/vm/inventory
@@ -56,12 +56,17 @@ zope.local.cnx.org
 [press:children]
 local.cnx.org
 
+[press_worker:children]
+local.cnx.org
+
 # Groups of groups
 
 [broker_connected:children]
 publishing
 channel_processing
 publishing_worker
+press
+press_worker
 
 [db_connected:children]
 archive
@@ -72,16 +77,15 @@ zclient
 pdf_gen
 backup
 press
+press_worker
 
 [nfs_connected:children]
-archive
-publishing
 legacy_frontend
-publishing_worker
 frontend
 zclient
 pdf_gen
 press
+press_worker
 
 [zope:children]
 zeo
@@ -92,3 +96,4 @@ pdf_gen
 zope
 publishing
 press
+press_worker


### PR DESCRIPTION
I unfortunately forgot to define `press_worker` in the inventory files and assign hosts to that host group. This rectifies that mistake.