### PR TITLE
Configuration touchups for Press

### DIFF
--- a/roles/press_common/templates/etc/cnx/press/vars.sh
+++ b/roles/press_common/templates/etc/cnx/press/vars.sh
@@ -1,8 +1,8 @@
 # this is a shell script which can be sourced into other scripts
 # to provide access to configuration values specific to this application
 
-SHARED_DIR="/var/cnx/apps/var"
-DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
-DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
-SENTRY_DSN="{{ sentry_dsn|default() }}"
-AMQP_URL="amqp://{{ press_broker_user }}:{{ press_broker_password }}@{{ hostvars[groups.broker[0]].ansible_default_ipv4.address }}:{{ broker_port|default(5672) }}/{{ press_broker_vhost|default(default_press_broker_vhost) }}"
+export SHARED_DIR="/var/cnx/apps/press/var"
+export DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
+export DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}"
+export SENTRY_DSN="{{ sentry_dsn|default() }}"
+export AMQP_URL="amqp://{{ press_broker_user }}:{{ press_broker_password }}@{{ hostvars[groups.broker[0]].ansible_default_ipv4.address }}:{{ broker_port|default(5672) }}/{{ press_broker_vhost|default(default_press_broker_vhost) }}"

--- a/roles/press_worker/templates/etc/supervisor/conf.d/press_celery_workers.conf
+++ b/roles/press_worker/templates/etc/supervisor/conf.d/press_celery_workers.conf
@@ -4,7 +4,7 @@ user=www-data
 directory=/var/cnx/apps/press
 process_name=%(program_name)s-%(process_num)s
 environment=SHARED_DIR="/var/cnx/apps/press/var",DB_URL="postgresql://{{ press_db_user }}:{{ press_db_password }}@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}",DB_SUPER_URL="postgresql://postgres@{{ press_db_host }}:{{ press_db_port }}/{{ press_db_name }}",SENTRY_DSN="{{ sentry_dsn|default() }}",AMQP_URL="amqp://{{ press_broker_user }}:{{ press_broker_password }}@{{ hostvars[groups.broker[0]].ansible_default_ipv4.address }}:{{ broker_port|default(5672) }}/{{ press_broker_vhost|default(default_press_broker_vhost) }}"
-command=/var/cnx/venvs/press/bin/celery worker -A press -Q default
+command=/var/cnx/venvs/press/bin/celery worker -A press
 
 {% endfor %}
 


### PR DESCRIPTION
- fix the `var.sh` config so that it can be `source`d
- Adjust the celery process to use the default queue

This can be changed later to enable more than one queue, but at this time we're just using the one queue. For example, we'll end up adding "beat" to this later for cron-like jobs.