### PR TITLE
Compress backend responses in haproxy

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -10,7 +10,7 @@
     # rsyslog only picks up the newly added haproxy logging config after restart.
     - restart rsyslog
 
-- name: configure haproxy ping monitoring
+- name: configure haproxy
   become: yes
   blockinfile:
     dest: /etc/haproxy/haproxy.cfg
@@ -27,6 +27,10 @@
         # If a client is bound to a particular backend but it goes down,
         # send them to a different one
         option redispatch
+        # Enable gzip compression
+        compression algo gzip
+        compression type text/plain text/css text/html application/json application/javascript text/xml application/xml application/xml+rss text/javascript
+
         monitor-uri /haproxy-ping
 
         timeout connect 7s


### PR DESCRIPTION
Nginx is also doing this compression, but not all requests go through nginx, and haproxy pipes some requests for large files directly to nginx, so we do need it in both places.

This PR will compress archive responses, resulting in a small improvement in load times. For example, featured links (extras) load in 11ms with this PR vs 13ms without on a good connection (2.3s vs 2.8s on the Chrome slow 3g setting)