### PR TITLE
Enable gzip_static nginx module

### DIFF
--- a/roles/nginx/files/etc/nginx/nginx.conf
+++ b/roles/nginx/files/etc/nginx/nginx.conf
@@ -47,6 +47,7 @@ http {
 	gzip on;
 	gzip_disable "msie6";
 
+	gzip_static on;
 	gzip_vary on;
 	gzip_proxied any;
 	gzip_comp_level 6;


### PR DESCRIPTION
Makes nginx serve pre-gzipped files, if available.

Goes with https://github.com/Connexions/webview/pull/1817