### PR TITLE
Downgrade from Press v4.1.0 to v4.0.0

### DIFF
--- a/environments/__prod_envs/vars/versions.yml
+++ b/environments/__prod_envs/vars/versions.yml
@@ -1,3 +1,3 @@
 ---
 webview_version: v0.34.1
-press_version: v4.1.0
+press_version: v4.0.0


### PR DESCRIPTION
We're not sure the feature in Press v4.1.0 is ready for the mainstream yet. So we are downgrading to the prior version, which still has features to go out.