### PR TITLE
Set the Cache-Control headers for webview and static files in nginx

### DIFF
--- a/roles/static_files/templates/etc/nginx/sites-available/static_files
+++ b/roles/static_files/templates/etc/nginx/sites-available/static_files
@@ -16,7 +16,7 @@ server {
     }
 
     location ~ ^/files/(.+)$ {
-        expires   1y;
+        expires   1m;
         autoindex off;
         set $fname $1;
         add_header Content-Disposition "attachment; filename=$fname";

--- a/roles/static_files/templates/etc/nginx/sites-available/static_files
+++ b/roles/static_files/templates/etc/nginx/sites-available/static_files
@@ -8,12 +8,15 @@ server {
     listen   8080;
     listen   [::]:8080 default ipv6only=on;  ## listen for ipv6
     port_in_redirect off;
+    expires          -1;
 
     location /specials {
+        expires    1m;
         add_header Access-Control-Allow-Origin $cors_header;
     }
 
     location ~ ^/files/(.+)$ {
+        expires   1y;
         autoindex off;
         set $fname $1;
         add_header Content-Disposition "attachment; filename=$fname";

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -5,6 +5,7 @@ server {
     root            /var/www/webview;
     index           index.html;
     try_files       $uri $uri/ /index.html;
+    expires         -1;
 
     location /ping {
         add_header Content-Length 0;
@@ -68,6 +69,7 @@ server {
     # and if they do not exist, fall back to cnx-authoring
     # from http://linuxplayer.org/2013/06/nginx-try-files-on-multiple-named-location-or-server
     location ~ ^/resources/.+ {
+        expires          1y;
         proxy_set_header Host {{ arclishing_domain }};
         proxy_pass http://localhost:{{ varnish_port }};
         proxy_intercept_errors on;
@@ -76,21 +78,25 @@ server {
     }
 
     location /resources/ {
+        expires          1y;
         proxy_set_header Host {{ arclishing_domain }};
         proxy_pass http://localhost:{{ varnish_port }};
     }
 
     location ~ ^.*/(data|scripts|styles|images|fonts)/(.*) {
+        expires     1m;
         try_files   $uri $uri/ /$1/$2 =404;
     }
 
     location ~ /exports/(.+?)/(.+)$ {
+        expires     1y;
         root        /var/www/;
         add_header  Content-Disposition "attachment; filename=$2";
         try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1 {% endfor %} =404;
     }
 
     location ~ /exports/(.+)$ {
+        expires     1y;
         root        /var/www/;
         add_header  Content-Disposition "attachment; filename=$1";
         try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1 {% endfor %} =404;


### PR DESCRIPTION
Since nginx is the closest thing we have to a backend for webview and static files.

Caching is hard so nothing is set in stone. Comments welcome. Probably good to do a test deployment to -dev before merging.