### PR TITLE
Update cnx-archive to 4.2.1

### DIFF
--- a/environments/__prod_envs/files/archive-requirements.txt
+++ b/environments/__prod_envs/files/archive-requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 Beaker==1.10.0
 certifi==2018.4.16
 chardet==3.0.4
-cnx-archive==4.2.0
+cnx-archive==4.2.1
 cnx-db==2.3.2
 cnx-epub==0.13.0
 cnx-query-grammar==0.2.2

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -5,7 +5,7 @@ billiard==3.5.0.4
 celery==4.2.1
 certifi==2018.4.16
 chardet==3.0.4
-cnx-archive==4.2.0
+cnx-archive==4.2.1
 cnx-db==2.3.2
 cnx-easybake==1.1.0
 cnx-epub==0.13.0


### PR DESCRIPTION
Pyup-bot seems to be asleep again, so hand creating this PR - upgrades cnx-archive to 4.2.1, to fix 
https://github.com/Connexions/cnx-archive/issues/586