### PR TITLE
Downgrade cnxdb 2.3.2 to 2.3.0

### DIFF
--- a/environments/__prod_envs/files/archive-requirements.txt
+++ b/environments/__prod_envs/files/archive-requirements.txt
@@ -3,7 +3,7 @@ Beaker==1.10.0
 certifi==2018.4.16
 chardet==3.0.4
 cnx-archive==4.2.1
-cnx-db==2.3.2
+cnx-db==2.3.0
 cnx-epub==0.13.0
 cnx-query-grammar==0.2.2
 db-migrator==1.1.0

--- a/environments/__prod_envs/files/archive-requirements.txt
+++ b/environments/__prod_envs/files/archive-requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 Beaker==1.10.0
 certifi==2018.4.16
 chardet==3.0.4
-cnx-archive==4.2.0
+cnx-archive==4.2.1
 cnx-db==2.3.2
 cnx-epub==0.13.0
 cnx-query-grammar==0.2.2

--- a/environments/__prod_envs/files/press-requirements.txt
+++ b/environments/__prod_envs/files/press-requirements.txt
@@ -4,7 +4,7 @@ bravado-core==5.0.5
 celery==4.2.1
 certifi==2018.4.16
 chardet==3.0.4
-cnx-db==2.3.2
+cnx-db==2.3.0
 cnx-litezip==1.3.1
 cnxml==2.1.1
 gunicorn==19.8.1

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -5,7 +5,7 @@ billiard==3.5.0.4
 celery==4.2.1
 certifi==2018.4.16
 chardet==3.0.4
-cnx-archive==4.2.0
+cnx-archive==4.2.1
 cnx-db==2.3.2
 cnx-easybake==1.1.0
 cnx-epub==0.13.0

--- a/environments/__prod_envs/files/publishing-requirements.txt
+++ b/environments/__prod_envs/files/publishing-requirements.txt
@@ -6,7 +6,7 @@ celery==4.2.1
 certifi==2018.4.16
 chardet==3.0.4
 cnx-archive==4.2.1
-cnx-db==2.3.2
+cnx-db==2.3.0
 cnx-easybake==1.1.0
 cnx-epub==0.13.0
 cnx-publishing==0.13.0


### PR DESCRIPTION
This downgrades cnx-db to remove the abstract html trigger. I've since found that it fires at the wrong time, so instead need to track the module_files_add trigger and find out why it's not doing the expected abstract transforms.