### PR TITLE
Produce a lean database dump file for testing

### DIFF
--- a/roles/backup/files/usr/local/bin/generate_lean_query.py
+++ b/roles/backup/files/usr/local/bin/generate_lean_query.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import json
+import sys
+from urllib.request import urlopen
+
+
+OPENSTAX_BOOKS_URL = "https://openstax.org/api/v2/pages/?type=books.Book&limit=1000&fields=title,cnx_id"
+
+SQL_TEMPLATE = """\
+BEGIN;
+-- FIXME: in 20180816211433_dumpable-functions, but not in production yet
+CREATE OR REPLACE FUNCTION
+ short_ident_hash(uuid uuid, major integer, minor integer)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE
+AS \$\$ select public.short_id(uuid) || '@' || concat_ws('.', major, minor) \$\$
+;
+-- A temporary table to store the results of our query, which will be used twice
+CREATE TEMPORARY TABLE to_be_saved (module_ident INT);
+WITH RECURSIVE ttt(nodeid, documentid, title, path) AS (
+    -- Collections that are OpenStax maintained
+    SELECT nodeid, documentid, title, ARRAY[nodeid] FROM trees AS t WHERE t.documentid = ANY(SELECT module_ident FROM modules WHERE uuid = ANY('{ids}'::UUID[]))
+  UNION ALL
+    -- Lookup all the Modules associated with these Collections
+    SELECT t.nodeid, t.documentid, t.title, ttt.path || ARRAY[t.nodeid]
+    FROM trees AS t JOIN ttt ON (t.parent_id = ttt.nodeid)
+    WHERE NOT t.nodeid = ANY(ttt.path)
+) INSERT INTO to_be_saved SELECT DISTINCT documentid FROM ttt WHERE documentid IS NOT NULL;
+-- * list of things to save
+select count(*) from modules where module_ident in (SELECT module_ident FROM to_be_saved);
+--  count 
+-- -------
+--  47784
+-- (1 row)
+-- * list of things to save that have parentage
+select count(*) from modules where module_ident in (SELECT module_ident FROM to_be_saved) and parent is not null;
+--  count 
+-- -------
+--   3292
+-- (1 row)
+-- * list of things to save that will need to disconnect parentage
+select count(*) from modules where module_ident in (SELECT module_ident FROM to_be_saved) and parent not in (SELECT module_ident FROM to_be_saved);
+--  count 
+-- -------
+--   1177
+-- (1 row)
+-- * list of things to be removed
+select count(*) from modules where module_ident not in (SELECT module_ident FROM to_be_saved);
+--  count  
+-- --------
+--  344902
+-- (1 row)
+-- Disconnect to be saved modules parents from modules that will be removed
+UPDATE modules SET parent = NULL WHERE module_ident IN (SELECT module_ident FROM to_be_saved) AND parent NOT IN (SELECT module_ident FROM to_be_saved);
+-- UPDATE 1177
+-- Delete the modules that are not OpenStax content
+DELETE FROM modules WHERE module_ident NOT IN (SELECT module_ident FROM to_be_saved);
+COMMIT;"""
+
+
+def get_openstax_book_ids():
+    try:
+        resp = urlopen(OPENSTAX_BOOKS_URL)
+    except Exception:
+        sys.exit(1)
+    data = json.load(resp)
+    return [x['cnx_id'] for x in data['items']]
+
+
+def _format_as_pg_array(l):
+    return '{' + ','.join(l) + '}'
+
+
+def main():
+    books = get_openstax_book_ids()
+    # BBB Manually add "Introduction to Sociology [1e]"
+    books.append('afe4332a-c97f-4fc4-be27-4e4d384a32d8')
+    print(SQL_TEMPLATE.format(ids=_format_as_pg_array(books)))
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -88,6 +88,15 @@
     dest: /etc/cron.weekly/zz-90-backup-cnx-{{ inventory_dir | basename }}
     mode: 0755
 
+- name: install lean query generating script
+  become: yes
+  when:
+    - slim_dumps | default(False)
+  file:
+    src: usr/local/bin/generate_lean_query.py
+    dest: /usr/local/bin/generate_lean_query.py
+    mode: 0755
+
 - name: install slim dump script
   become: yes
   when:

--- a/roles/backup/templates/usr/local/bin/cnx-slim-dump
+++ b/roles/backup/templates/usr/local/bin/cnx-slim-dump
@@ -7,8 +7,12 @@
 #    ssh)
 
 # Target databases settings
-SLIM_DUMP_DB_NAME=cnx_slim_dump
-SLIM_DUMP_FILENAME="/var/backups/$SLIM_DUMP_DB_NAME.$(date +%Y-%m-%d).sql.gz"
+DUMP_BASE_DIR="/var/backups/"
+DUMP_DB_NAME=cnx_dev_dump
+SLIM_DUMP_NAME=cnx_slim_dump
+LEAN_DUMP_NAME=cnx_lean_dump
+SLIM_DUMP_FILENAME="$DUMP_BASE_DIR$SLIM_DUMP_NAME.$(date +%Y-%m-%d).sql.gz"
+LEAN_DUMP_FILENAME="$DUMP_BASE_DIR$LEAN_DUMP_NAME.$(date +%Y-%m-%d).sql.gz"
 
 # Source databases settings
 ARCHIVE_DB_HOST={{ archive_db_host }}
@@ -16,48 +20,62 @@ ARCHIVE_DB_PORT={{ archive_db_port }}
 ARCHIVE_DB_USER={{ archive_db_user }}
 ARCHIVE_DB_NAME={{ archive_db_name }}
 
-# Only set SSH_USER if pg_dump cannot access the production database
-SSH_USER=
+
+function cleanUpDumps {
+    # Only keep 3 copies the dump
+    bname=$(basename $1)
+    ls -1 -r $(dirname $1)/${bname/.*/}* | sed -n '4,$ p' | xargs rm -f
+}
 
 # Install clean up code
-function cleanup {
-    # Only keep 3 copies of slim dump
-    bname=$(basename $SLIM_DUMP_FILENAME)
-    ls -1 -r $(dirname $SLIM_DUMP_FILENAME)/${bname/.*/}* | sed -n '4,$ p' | xargs rm -f
-    psql -U postgres -c "DROP DATABASE IF EXISTS $SLIM_DUMP_DB_NAME;"
+function cleanUp {
+    cleanUpDumps $SLIM_DUMP_FILENAME
+    cleanUpDumps $LEAN_DUMP_FILENAME
+    psql -U postgres -c "DROP DATABASE IF EXISTS $DUMP_DB_NAME;"
 }
-trap cleanup EXIT
+trap cleanUp EXIT
+
 
 # 1. Create a temporary database for the slim dump
 psql -U postgres <<EOF
-DROP DATABASE IF EXISTS $SLIM_DUMP_DB_NAME;
-CREATE DATABASE $SLIM_DUMP_DB_NAME;
+DROP DATABASE IF EXISTS $DUMP_DB_NAME;
+CREATE DATABASE $DUMP_DB_NAME;
 EOF
+
 
 # 2. Copy the production database (or a backup of)
 if [[ -z "$SSH_USER" ]]
 then
     pg_dump -h "$ARCHIVE_DB_HOST" -p "$ARCHIVE_DB_PORT" -U "$ARCHIVE_DB_USER" \
-        "$ARCHIVE_DB_NAME" | psql -U postgres $SLIM_DUMP_DB_NAME
+        "$ARCHIVE_DB_NAME" | psql -U postgres $DUMP_DB_NAME
 else
     ssh -l $SSH_USER $ARCHIVE_DB_HOST pg_dump -U "$ARCHIVE_DB_USER" \
-        "$ARCHIVE_DB_NAME" | psql -U postgres $SLIM_DUMP_DB_NAME
+        "$ARCHIVE_DB_NAME" | psql -U postgres $DUMP_DB_NAME
 fi
+
 
 # 3. Replace the resource files in cnx_slim_dump with dummy files except
 #    index.cnxml, index.cnxml.html, index_auto_generated.cnxml, ruleset.css,
 #    featured-cover.png
-psql -U postgres $SLIM_DUMP_DB_NAME <<EOF
+psql -U postgres $DUMP_DB_NAME <<EOF
 ALTER TABLE files DISABLE TRIGGER USER;
 
-UPDATE files SET file = 'dummy'
-    WHERE NOT EXISTS (
-        SELECT 1 FROM module_files
-        WHERE filename IN ('index.cnxml', 'index.cnxml.html',
-                           'index_auto_generated.cnxml',
-                           'ruleset.css', 'featured-cover.png',
-                           'collection.xml')
-          AND files.fileid = module_files.fileid);
+WITH files_to_keep AS (
+  SELECT fileid
+  FROM module_files natural join files
+  WHERE
+    filename IN ('index.cnxml', 'index.cnxml.html',
+                 'index_auto_generated.cnxml',
+                 'ruleset.css', 'featured-cover.png',
+                 'collection.xml')
+    AND files.fileid = module_files.fileid
+UNION
+  SELECT fileid
+  FROM collated_file_associations
+)
+UPDATE files
+SET file = 'dummy'
+WHERE fileid not in (SELECT distinct fileid FROM files_to_keep);
 
 -- dummy 1x1.png file from https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png
 UPDATE files SET file = '\\x89504e470d0a1a0a0000000d494844520000000100000001010300000025db56ca00000003504c5445000000a77a3dda0000000174524e530040e6d8660000000a4944415408d76360000000020001e221bc330000000049454e44ae426082'
@@ -69,5 +87,14 @@ UPDATE files SET file = '\\x89504e470d0a1a0a0000000d4948445200000001000000010103
 ALTER TABLE files ENABLE TRIGGER USER;
 EOF
 
-# 4. Create a database dump file for download
-pg_dump -U postgres $SLIM_DUMP_DB_NAME | gzip > $SLIM_DUMP_FILENAME
+
+# 4. Create a slim database dump file for download
+pg_dump -U postgres $DUMP_DB_NAME | gzip > $SLIM_DUMP_FILENAME
+
+
+# 5. Lean out the database to have only OpenStax content
+${PWD}/generate_lean_query.py | psql -U postgres -d $DUMP_DB_NAME -a
+
+
+# 6. Create a lean database dump file for download
+pg_dump -U postgres $DUMP_DB_NAME | gzip > $LEAN_DUMP_FILENAME


### PR DESCRIPTION
This produces a lean database dump file along side the existing slim dump
file. The lean dump focuses on openstax authored content and drops everything
else.

This also fixes the slim dump to include baked content. (This does increase
the size of the slim dump slightly.)

Same as https://github.com/Connexions/devops/pull/21