### PR TITLE
add canonical links to exports via nginx as well

### DIFF
--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -97,7 +97,7 @@ server {
     }
 
 
-    location ~ /exports/(.+?)(\.[^/]+)/(.+)(\.[^/]+)$ {
+    location ~ /exports/(.+?)(\.[^/]+)/(.+?)(\.[^/]+)$ {
         expires     1y;
         root        /var/www/;
         add_header  Link "<https://{{ frontend_domain }}/contents/$1/$3> ;rel=\"Canonical\""
@@ -105,8 +105,7 @@ server {
         try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1$2 {% endfor %} =404;
     }
 
-    location ~ /exports/(.+)$ {
-    location ~ /exports/(.+)(\.[^/]+)$ {
+    location ~ /exports/(.+?)(\.[^/]+)$ {
         expires     1y;
         root        /var/www/;
         add_header  Link "<https://{{ frontend_domain }}/contents/$1> ;rel=\"Canonical\"";

--- a/roles/webview/templates/etc/nginx/sites-available/webview
+++ b/roles/webview/templates/etc/nginx/sites-available/webview
@@ -96,18 +96,22 @@ server {
         try_files   $uri $uri/ /$1/$2 =404;
     }
 
-    location ~ /exports/(.+?)/(.+)$ {
+
+    location ~ /exports/(.+?)(\.[^/]+)/(.+)(\.[^/]+)$ {
         expires     1y;
         root        /var/www/;
-        add_header  Content-Disposition "attachment; filename=$2";
-        try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1 {% endfor %} =404;
+        add_header  Link "<https://{{ frontend_domain }}/contents/$1/$3> ;rel=\"Canonical\""
+        add_header  Content-Disposition "attachment; filename=$3$4";
+        try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1$2 {% endfor %} =404;
     }
 
     location ~ /exports/(.+)$ {
+    location ~ /exports/(.+)(\.[^/]+)$ {
         expires     1y;
         root        /var/www/;
-        add_header  Content-Disposition "attachment; filename=$1";
-        try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1 {% endfor %} =404;
+        add_header  Link "<https://{{ frontend_domain }}/contents/$1> ;rel=\"Canonical\"";
+        add_header  Content-Disposition "attachment; filename=$1$2";
+        try_files   {% for dir in archive_exports_directories|default(default_archive_exports_directories) %}/{{ dir }}/$1$2 {% endfor %} =404;
     }
 
     location /nginx_status {


### PR DESCRIPTION
When we changed vanish to use nginx to serve /exports links, we bypassed the canonical-link code that just rolled out in archive. This does the same work in the nginx config.