### PR TITLE
Zodb backup fix

### DIFF
--- a/roles/backup/files/usr/local/bin/cnx-backup-zodb
+++ b/roles/backup/files/usr/local/bin/cnx-backup-zodb
@@ -4,7 +4,8 @@ zodb_host=$1
 
 backup_ssh_key=~backup/.ssh/${zodb_host}_id_rsa
 
-source=/var/lib/cnx/cnx-buildout/var/filestorage/Data.fs
+# uses a directory relative to the restricted directory specified in the backup user's authorized_keys on the source server
+source=zodb/Data.fs
 
 backup_dir=/var/backups/cnx-backups
 zodb_dump_base_name=cnx-$zodb_host-Data.fs.$(date +%y-%m-%d)

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -56,6 +56,15 @@
   delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
   register: remote_backup_user
 
+- name: install restricted rsync script (provided with rsync)
+  become: yes
+  unarchive:
+    src: /usr/share/doc/rsync/scripts/rrsync.gz
+    dest: /usr/local/bin
+    remote_src: yes
+    mode: 0755
+  delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
+
 - name: add authorized key to zodb server with restricted execution
   become: yes
   authorized_key:

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -52,14 +52,32 @@
   user:
     name: backup
     state: present
+    shell: /bin/bash
   delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
   register: remote_backup_user
 
-- name: add authorized key to zodb server
+- name: add authorized key to zodb server with restricted execution
   become: yes
   authorized_key:
     user: backup
     key: "{{ key_result.ssh_public_key }}"
+    key_options: 'command="/usr/local/bin/rrsync -ro /var/backups/cnx-files",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding'
+  delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
+
+- name: create directory for restricted rsync
+  become: yes
+  files:
+    path: "{{ remote_backup_user.home }}/cnx-files"
+    state: directory
+    mode: 0755
+  delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
+
+- name: create zodb symlink
+  become: yes
+  file:
+    src: /var/lib/cnx/cnx-buildout/var/filestorage
+    dest: "{{ remote_backup_user.home }}/cnx-files/zodb"
+    state: link
   delegate_to: "{{ hostvars[groups.zeo[0]].inventory_hostname }}"
 
 - name: create backup destination directory


### PR DESCRIPTION
changes backup user's shell from nologin to bash and restricts execution to the rrsync script and to the specified source directory