### PR TITLE
Use /extras as varnish backend probe, to verify DB access

### DIFF
--- a/roles/varnish/templates/etc/varnish/varnish.vcl
+++ b/roles/varnish/templates/etc/varnish/varnish.vcl
@@ -62,7 +62,8 @@ backend webview {
 }
 
 probe archive_probe {
-    .expected_response = 404;
+    .url = "/extras";
+    .expected_response = 200;
 }
 
 # archive waitress


### PR DESCRIPTION
Currently, if a DB backend goes down, archive instances that depend on that backend will still be viewed as "heathly" by the varnish-based load balancer, since the probe requests go to '/' and expect a 404. In  the future, we whould probably implement something at `/` that gives a general status. But for now, by changing the probe to fetch `/extras`, we verify that the DB is up, regardless of specific content.