### PR TITLE
Move database migration steps to its own playbook

### DIFF
--- a/database_migration.yml
+++ b/database_migration.yml
@@ -1,0 +1,28 @@
+---
+
+- name: migrate repository database
+  hosts: archive
+  tasks:
+    - name: stop archive
+      become: yes
+      supervisorctl:
+        name: "archive:"
+        state: stopped
+
+    - name: migrate repository database
+      become: yes
+      become_user: www-data
+      environment:
+        # If PGHOST is not set, psql tries to look for cluster "main" which doesn't
+        # work:
+        #     $ psql -U postgres -l
+        #     Error: Invalid data directory
+        # This appears to be a problem after a postgresql-common update
+        PGHOST: "{{ archive_db_host }}"
+      command: "/var/cnx/venvs/archive/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-db migrate"
+
+    - name: start archive
+      become: yes
+      supervisorctl:
+        name: "archive:"
+        state: started

--- a/environments/vm/group_vars/all.yml
+++ b/environments/vm/group_vars/all.yml
@@ -31,6 +31,7 @@ press_broker_password: press
 memcached_hosts: localhost
 
 varnish_port: 8990
+legacy_varnish_port: 8991
 haproxy_zcluster_port: 8998
 
 archive_host: archive.local.cnx.org

--- a/main.yml
+++ b/main.yml
@@ -29,6 +29,7 @@
 
 - import_playbook: archive.yml not_standalone=yes
 - import_playbook: publishing.yml not_standalone=yes
+- import_playbook: database_migration.yml
 - import_playbook: channel_processing.yml
 - import_playbook: publishing_worker.yml
 - import_playbook: authoring.yml

--- a/roles/publishing/tasks/main.yml
+++ b/roles/publishing/tasks/main.yml
@@ -2,24 +2,6 @@
 # Installs publishing with all the dependencies.
 
 # +++
-# Init databases
-# +++
-
-# BBB (3-Feb-12017) cnx-publishing-initdb is deprecated.
-- name: check for cnx-publishing-initdb
-  stat:
-    path: "/var/cnx/venvs/publishing/bin/cnx-publishing-initdb"
-  register: "publishing_initdb_executable"
-
-- name: trigger deprecated migration
-  # We check for the executable's existence because prior to its removal, the migrations lived in cnx-publishing.
-  when: "publishing_initdb_executable.stat.exists"
-  command: /bin/true
-  notify:
-    - migrate repository database (deprecated)
-# /BBB
-
-# +++
 # Init service
 # +++
 

--- a/roles/publishing_common/tasks/main.yml
+++ b/roles/publishing_common/tasks/main.yml
@@ -109,22 +109,6 @@
     - restart publishing workers
     - restart channel processing
 
-# FIXME this won't be necessary once publishing is >=0.7
-- name: check existence of publishing migrations
-  become: yes
-  become_user: www-data
-  stat:
-    path: "/var/cnx/venvs/publishing/lib/python2.7/site-packages/cnxpublishing/sql/migrations"
-  register: publishing_migrations_dir
-
-- name: migrate repository database
-  when: not publishing_migrations_dir.stat.exists
-  become: yes
-  become_user: www-data
-  command: /bin/true
-  notify:
-    - migrate repository database
-
 # +++
 # Configure
 # +++

--- a/roles/repository_db/handlers/main.yml
+++ b/roles/repository_db/handlers/main.yml
@@ -44,18 +44,3 @@
 - name: initialize repository database (dbmigrator init)
   command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/publishing/app.ini --context cnx-db init"
   listen: initialize repository database
-
-- name: migrate repository database
-  environment:
-    # If PGHOST is not set, psql tries to look for cluster "main" which doesn't
-    # work:
-    #     $ psql -U postgres -l
-    #     Error: Invalid data directory
-    # This appears to be a problem after a postgresql-common update
-    PGHOST: "{{ archive_db_host }}"
-  command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/archive/app.ini --context cnx-db migrate"
-
-
-# BBB (3-Feb-12017) Needs to be a handler
-- name: migrate repository database (deprecated)
-  command: "/var/cnx/venvs/publishing/bin/dbmigrator --config /etc/cnx/publishing/app.ini --context cnx-archive --context cnx-publishing migrate"


### PR DESCRIPTION
- Add legacy_varnish_port to vm environments group vars

  Add `legacy_varnish_port: 8991` to environments/vm/group_vars/all.yml,
  as is defined in all the other environments.  It is expected in one of
  the lead_load_balancer tasks.

- Move database migration steps to its own playbook

  Database migrations sometimes freeze when deploying to production.  The
  reason seems to be some schema changes attempt to acquire Access
  Exclusive Lock on busy tables (in the most recent case, creating a
  trigger on the modules table).
  
  A way to prevent this problem is to take archive down before running the
  migrations with schema changes, and bring archive up again when the
  migrations have finished.
  
  This only affects non-deferred migrations.  The deferred migrations
  continue to run while the site is up.

An attempt to fix #757
