### PR TITLE
Removed EPUB from download file types

### DIFF
--- a/roles/archive/templates/etc/cnx/archive/app.ini
+++ b/roles/archive/templates/etc/cnx/archive/app.ini
@@ -42,7 +42,6 @@ exports-directories =
 # type name:file extension,mimetype,user friendly name,description
 exports-allowable-types =
     pdf:pdf,application/pdf,PDF,PDF file, for viewing content offline and printing.
-    epub:epub,application/epub+zip,EPUB,Electronic book format file, for viewing on mobile devices.
     zip:zip,application/zip,Offline ZIP,An offline HTML copy of the content.  Also includes XML, included media files, and other support files.
 
 sitemap-destination = http://{{ frontend_domain }}/sitemap.xml


### PR DESCRIPTION
This should remove it from the Downloads tab