### PR TITLE
correct echo syntax for set_up_rhaptos_site scripts

### DIFF
--- a/tasks/set_up_rhaptos_site.yml
+++ b/tasks/set_up_rhaptos_site.yml
@@ -11,6 +11,6 @@
     chdir: "/var/lib/cnx/cnx-buildout"
 
 - name: set up collections allowed content types
-  shell: "echo \"app.plone.portal_types.Collection.allowed_content_types += ('UnifiedFile',); import transaction; transaction.commit()\" | ./bin/instance debug"
+  shell: "echo \"app.plone.portal_types.Collection.allowed_content_types += [('UnifiedFile',),()]['UnifiedFile' in app.plone.portal_types.Collection.allowed_content_types]; import transaction; transaction.commit()\" | ./bin/instance debug"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"

--- a/tasks/set_up_rhaptos_site.yml
+++ b/tasks/set_up_rhaptos_site.yml
@@ -6,11 +6,11 @@
     chdir: "/var/lib/cnx/cnx-buildout"
 
 - name: set up rhaptos print host
-  shell: "echo -c \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
+  shell: "echo \"app.plone.rhaptos_print._host = 'http://{{ frontend_domain }}'; import transaction; transaction.commit()\" | ./bin/instance debug"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"
 
 - name: set up collections allowed content types
-  shell: "echo -c \"app.plone.portal_types.Collection.allowed_content_types += ('UnifiedFile',); import transaction; transaction.commit()\" | ./bin/instance debug"
+  shell: "echo \"app.plone.portal_types.Collection.allowed_content_types += ('UnifiedFile',); import transaction; transaction.commit()\" | ./bin/instance debug"
   args:
     chdir: "/var/lib/cnx/cnx-buildout"


### PR DESCRIPTION
somehow, an extra `-c` snuck into a couple ansible tasks for rhaptos site setup (probably  was a `bash -c` line at some point). Remove them.

While we're here: make the UnifiedFile setup line idempotent:  don't want  repeats of the allowable type in there (this task is rerun whenever we copy a zodb to a new host, so it's an actual consideration)